### PR TITLE
Fix build on OSX

### DIFF
--- a/vterm-module.c
+++ b/vterm-module.c
@@ -1,6 +1,10 @@
 #include "vterm-module.h"
 #include <fcntl.h>
-#include <pty.h>
+#ifdef __APPLE__
+#  include <util.h>
+#else
+#  include <pty.h>
+#endif
 #include <signal.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
Thanks for tackling the integration of libvterm with emacs !

This PR should fix building the module on OSX, forkpty is available through util.h on OSX: http://www.unix.com/man-page/osx/3/forkpty/

A neater fix would be to start using autotools to build the module and in the configure phase set some ENV variables depending on the presence of one or the other lib on the OS, but this should do for now.

Test plan:
- Make on OSX => no errors, run vterm-create => terminal shows up
- Make on linux => no errors