### PR TITLE
Make vterm--process buffer-local

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -74,7 +74,7 @@ be send to the terminal."
 
 (defvar vterm--process nil
   "Shell process of current term.")
-(make-variable-buffer-local 'vterm--term)
+(make-variable-buffer-local 'vterm--process)
 
 (define-derived-mode vterm-mode fundamental-mode "VTerm"
   "Mayor mode for vterm buffer."


### PR DESCRIPTION
This causes problems related to window resizing. In `vterm--window-size-change`, `vterm--process` is checked but `vterm--term` is not. If there's a buffer where `vterm--process` is truthy but `vterm--term` isn't, `vterm--set-size` is called with a bogus first argument.

There probably needs to be a more robust guard here but this will do for starters.