### PR TITLE
Use append instead of nconc in vterm-mode

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -84,7 +84,7 @@ be send to the terminal."
   (setq-local scroll-conservatively 101)
   (setq-local scroll-margin 0)
   (add-hook 'window-size-change-functions #'vterm--window-size-change t t)
-  (let ((process-environment (nconc '("TERM=xterm") process-environment)))
+  (let ((process-environment (append '("TERM=xterm") process-environment)))
     (setq vterm--process (make-process
                           :name "vterm"
                           :buffer buffer


### PR DESCRIPTION
This one was surprising to me. Apparently list literals are only compiled once, so if you mutate them (with *nconc*) you get unexpected results.

```emacs-lisp
    (setq a nil)
    nil

    (setq a (nconc '(a) a))
    (a)

    ;; new list literal, so still expected results
    (setq a (nconc '(a) a))
    (a a)

    ;; re-use of the same list literal after being mutated
    (dotimes (- 2) (setq a (nconc '(a) a)))
    nil

    a
    (a a a a a . #2)  ;; circular list
```

After changing *nconc* to *append* you can run two vterms in the same Emacs session without it hanging.

Btw, happy to see you accepting PRs here. I'm excited for this initiative and if you don't mind I'll continue to fiddle with it.