### PR TITLE
Use CMake library search to look for libvterm location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,13 +2,33 @@ cmake_minimum_required(VERSION 3.0.2)
 
 project(emacs-libvterm C)
 
+# Look for the header file.
+find_path(LIBVTERM_INCLUDE_DIR NAMES
+    vterm.h
+    )
+
+if(NOT LIBVTERM_INCLUDE_DIR)
+  message(FATAL_ERROR "vterm.h not found")
+endif()
+
+find_library(LIBVTERM_LIBRARY NAMES
+  vterm
+  libvterm
+)
+
+if(NOT LIBVTERM_LIBRARY)
+  message(FATAL_ERROR "libvterm not found")
+endif()
+
+include_directories(${LIBVTERM_INCLUDE_DIR})
+
 add_library(vterm-module MODULE vterm-module.c utf8.c elisp.c)
 set_property(TARGET vterm-module PROPERTY POSITION_INDEPENDENT_CODE ON)
 set_target_properties(vterm-module PROPERTIES PREFIX "")
 set_target_properties(vterm-module PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 # Link with libvterm
-target_link_libraries(vterm-module vterm)
+target_link_libraries(vterm-module ${LIBVTERM_LIBRARY})
 
 # Custom run command for testing
 add_custom_target(run


### PR DESCRIPTION
On some platforms, the location of libvterm headers and library are
not in standard places that gcc/clang looks for by default.

The usual practice is to use find_path/find_library and then
link them properly. In my particular case, this helps clang to
find homebrew-installed libvterm on OS X.