### PR TITLE
check buffer-live-p in vterm--sentinel

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -243,8 +243,10 @@ Then triggers a redraw from the module."
 (defun vterm--sentinel (process event)
   "Sentinel of vterm PROCESS."
   (when (not (process-live-p process))
-    (with-current-buffer (process-buffer process)
-      (run-hooks 'vterm-exit-hook))))
+    (let ((buf (process-buffer process)))
+      (when (buffer-live-p buf)
+        (with-current-buffer buf
+          (run-hooks 'vterm-exit-hook))))))
 
 (defun vterm--window-size-change (frame)
   "Callback triggered by a size change of the FRAME.


### PR DESCRIPTION
without this patch I would get 
```
error in process sentinel: save-current-buffer: Selecting deleted buffer
error in process sentinel: Selecting deleted buffer
```
if I set 
```
(defun vmacs-vterm-hook()
  (let ((p (get-buffer-process (current-buffer))))
    (when p
      (set-process-query-on-exit-flag p nil))))

(add-hook 'vterm-mode-hook 'vmacs-vterm-hook)

```