### PR TITLE
support set terminal title .

### DIFF
--- a/elisp.c
+++ b/elisp.c
@@ -143,3 +143,6 @@ emacs_value get_hex_color_bg(emacs_env *env, emacs_value face) {
   return env->funcall(env, Fvterm_face_color_hex, 2,
                       (emacs_value[]){face, Qbackground});
 }
+void set_title(emacs_env *env, emacs_value string) {
+   env->funcall(env, Fvterm_set_title, 1, (emacs_value[]){string});
+}

--- a/elisp.h
+++ b/elisp.h
@@ -39,6 +39,7 @@ emacs_value Fvterm_flush_output;
 emacs_value Fblink_cursor_mode;
 emacs_value Fget_buffer_window;
 emacs_value Fselected_window;
+emacs_value Fvterm_set_title;
 
 // Utils
 void bind_function(emacs_env *env, const char *name, emacs_value Sfun);
@@ -67,5 +68,6 @@ void recenter(emacs_env *env, emacs_value pos);
 void forward_char(emacs_env *env, emacs_value n);
 emacs_value get_buffer_window(emacs_env *env);
 emacs_value selected_window(emacs_env *env);
+void set_title(emacs_env *env, emacs_value string) ;
 
 #endif /* ELISP_H */

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -203,7 +203,8 @@ static void refresh_screen(Term *term, emacs_env *env) {
     // Term height may have decreased before `invalid_end` reflects it.
     int line_start = row_to_linenr(term, term->invalid_start);
     goto_line(env, line_start);
-    delete_lines(env, line_start, term->invalid_end - term->invalid_start, true);
+    delete_lines(env, line_start, term->invalid_end - term->invalid_start,
+                 true);
     refresh_lines(term, env, term->invalid_start, term->invalid_end, width);
   }
 
@@ -320,9 +321,9 @@ static void term_redraw(Term *term, emacs_env *env) {
         env->extract_integer(env, buffer_line_number(env)) - bufline_before;
     adjust_topline(term, env, line_added);
   }
-  if(term->is_title_changed){
-    set_title(env,env->make_string(env, term->title,strlen(term->title)));
-    term->is_title_changed=false;
+  if (term->is_title_changed) {
+    set_title(env, env->make_string(env, term->title, strlen(term->title)));
+    term->is_title_changed = false;
   }
   term->is_invalidated = false;
 }
@@ -357,16 +358,16 @@ static bool is_key(unsigned char *key, size_t len, char *key_description) {
   return (len == strlen(key_description) &&
           memcmp(key, key_description, len) == 0);
 }
-static void term_set_title(Term *term ,char* title) {
-  size_t len=strlen(title);
-  if (term->title){
+static void term_set_title(Term *term, char *title) {
+  size_t len = strlen(title);
+  if (term->title) {
     free(term->title);
   }
-  term->title=malloc(sizeof(char) * (len+1));
-  strncpy(term->title ,title,len);
-  term->title[len]=0;
-  term->is_title_changed=true;
-  return ;
+  term->title = malloc(sizeof(char) * (len + 1));
+  strncpy(term->title, title, len);
+  term->title[len] = 0;
+  term->is_title_changed = true;
+  return;
 }
 
 static int term_settermprop(VTermProp prop, VTermValue *val, void *user_data) {
@@ -378,7 +379,7 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *user_data) {
     term->cursor.visible = val->boolean;
     break;
   case VTERM_PROP_TITLE:
-    term_set_title(term,val->string);
+    term_set_title(term, val->string);
     break;
   case VTERM_PROP_CURSORBLINK:
     term->cursor.blinking = val->boolean;
@@ -560,9 +561,9 @@ static void term_finalize(void *object) {
   for (int i = 0; i < term->sb_current; i++) {
     free(term->sb_buffer[i]);
   }
-  if (term->title){
+  if (term->title) {
     free(term->title);
-    term->title=NULL;
+    term->title = NULL;
   }
 
   free(term->sb_buffer);
@@ -596,7 +597,7 @@ static emacs_value Fvterm_new(emacs_env *env, ptrdiff_t nargs,
   term->cursor.visible = true;
   term->cursor.blinking = false;
   term->title = NULL;
-  term->is_title_changed=false;
+  term->is_title_changed = false;
 
   return env->make_user_ptr(env, term_finalize, term);
 }

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -48,6 +48,8 @@ typedef struct Term {
   bool is_invalidated;
 
   Cursor cursor;
+  char *title;
+  bool is_title_changed;
 } Term;
 
 // Faces

--- a/vterm.el
+++ b/vterm.el
@@ -61,6 +61,22 @@ value with `add-hook'."
   :type 'hook
   :group 'vterm)
 
+(defcustom vterm-set-title-hook nil
+  "Shell set title hook.
+
+those functions are called one by one, with 1 arguments.
+`vterm-set-title-hook' should be a symbol, a hook variable.
+The value of HOOK may be nil, a function, or a list of functions.
+for example
+(defun vterm--rename-buffer-as-title (title)
+  (rename-buffer (format \"vterm %s\" title)))
+(add-hook 'vterm-set-title-hook 'vterm--rename-buffer-as-title)
+
+see http://tldp.org/HOWTO/Xterm-Title-4.html about how to set terminal title
+for different shell. "
+  :type 'hook
+  :group 'vterm)
+
 (defface vterm
   '((t :inherit default))
   "Default face to use in Term mode."
@@ -266,6 +282,12 @@ Feeds the size change to the virtual terminal."
 (defun vterm--buffer-line-num()
   "Return the maximum line number."
   (line-number-at-pos (point-max)))
+
+(defun vterm--set-title (title)
+  (run-hook-with-args 'vterm-set-title-hook title))
+
+
+
 
 (provide 'vterm)
 ;;; vterm.el ends here

--- a/vterm.el
+++ b/vterm.el
@@ -264,8 +264,10 @@ Feeds the size change to the virtual terminal."
 
 
 (defun vterm--delete-lines (line-num count &optional delete-whole-line)
-  "Delete lines from line-num. If option ‘kill-whole-line’ is non-nil,
- then this command kills the whole line including its terminating newline"
+  "Delete COUNT lines from LINE-NUM.
+
+ If option DELETE-WHOLE-LINE is non-nil, then this command kills
+ the whole line including its terminating newline"
   (save-excursion
     (when (vterm--goto-line line-num)
       (delete-region (point) (point-at-eol count))
@@ -274,7 +276,7 @@ Feeds the size change to the virtual terminal."
         (delete-char 1)))))
 
 (defun vterm--goto-line(n)
-  "If move succ return t"
+  "Go to line N and return true on success."
   (goto-char (point-min))
   (let ((succ (eq 0 (forward-line (1- n)))))
     succ))
@@ -284,9 +286,8 @@ Feeds the size change to the virtual terminal."
   (line-number-at-pos (point-max)))
 
 (defun vterm--set-title (title)
+  "Run the `vterm--set-title-hook' with TITLE as argument."
   (run-hook-with-args 'vterm-set-title-hook title))
-
-
 
 
 (provide 'vterm)


### PR DESCRIPTION
```
(defun vterm--auto-rename-buffer (title)
  (rename-buffer (format "vterm %s" title)))
(add-hook 'vterm-set-title-hook 'vterm--auto-rename-buffer)

```

 set terminal title dynamically to the current working directory
```
        precmd() {
            print -Pn "\e]0;%~ $1\a"
        }

```
see http://tldp.org/HOWTO/Xterm-Title-4.html about how to set terminal title
for different shell. 