### PR TITLE
Fix auto-install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set_target_properties(vterm-module PROPERTIES
   C_STANDARD 99
   POSITION_INDEPENDENT_CODE ON
   PREFIX ""
+  LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}
   )
 
 # Link with libvterm

--- a/vterm.el
+++ b/vterm.el
@@ -7,25 +7,26 @@
 
 ;;; Code:
 
+;;;###autoload
 (defun vterm-module-compile ()
   "This function compiles the vterm-module."
   (interactive)
-  (let ((buffer (get-buffer-create " *Install vterm"))
-        (default-directory (file-name-directory (locate-library "vterm"))))
-    (make-process
-     :name "build-vterm-module"
-     :buffer buffer
-     :command '("sh" "-c" "mkdir -p build; cd build; cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; make")
-     :stderr buffer
-     :sentinel (lambda (process status)
-                 (if (equal status "finished\n")
-                     (progn (let ((buffer (process-buffer process)))
-                              (bury-buffer buffer)
-                              (when-let ((window (get-buffer-window buffer)))
-                                (delete-window window)))
-                            (message "Sucessfully compiled the emacs-libvterm module."))
-                   (message "Compilation of libvterm has failed."))))
-    (pop-to-buffer buffer)))
+  (let ((default-directory (file-name-directory (locate-library "vterm"))))
+    (unless (file-executable-p (concat default-directory "vterm-module.so" ))
+      (let ((buffer (get-buffer-create " *Install vterm")))
+        (pop-to-buffer buffer)
+        (let ((status (call-process "sh" nil buffer t "-c"
+                                    "mkdir -p build;                             \
+                                     cd build;                                   \
+                                     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; \
+                                     make")))
+          (if (eq status 0)
+              (progn
+                (bury-buffer buffer)
+                (when-let ((window (get-buffer-window buffer)))
+                  (delete-window window))
+                (message "Compilation of emacs-libvterm module succeeded"))
+            (message "Compilation of emacs-libvterm module failed")))))))
 
 (when (boundp 'vterm-install)
   (vterm-module-compile))

--- a/vterm.el
+++ b/vterm.el
@@ -136,7 +136,7 @@ for different shell. "
 (make-variable-buffer-local 'vterm--process)
 
 (define-derived-mode vterm-mode fundamental-mode "VTerm"
-  "Mayor mode for vterm buffer."
+  "Major mode for vterm buffer."
   (buffer-disable-undo)
   (setq vterm--term (vterm--new (window-body-height)
                                 (window-body-width)
@@ -148,14 +148,19 @@ for different shell. "
 
   (add-hook 'window-size-change-functions #'vterm--window-size-change t t)
   (let ((process-environment (append '("TERM=xterm") process-environment)))
-    (setq vterm--process (make-process
-                          :name "vterm"
-                          :buffer (current-buffer)
-                          :command `("/bin/sh" "-c" ,(format "stty -nl sane iutf8 rows %d columns %d >/dev/null && exec %s" (window-body-height) (window-body-width) vterm-shell))
-                          :coding 'no-conversion
-                          :connection-type 'pty
-                          :filter #'vterm--filter
-                          :sentinel (when vterm-exit-hook #'vterm--sentinel)))))
+    (setq vterm--process
+          (make-process
+           :name "vterm"
+           :buffer (current-buffer)
+           :command `("/bin/sh" "-c"
+                      ,(format "stty -nl sane iutf8 rows %d columns %d >/dev/null && exec %s"
+                               (window-body-height)
+                               (window-body-width)
+                               vterm-shell))
+           :coding 'no-conversion
+           :connection-type 'pty
+           :filter #'vterm--filter
+           :sentinel (when vterm-exit-hook #'vterm--sentinel)))))
 
 ;; Keybindings
 (define-key vterm-mode-map [tab]                       #'vterm--self-insert)

--- a/vterm.el
+++ b/vterm.el
@@ -7,13 +7,16 @@
 
 ;;; Code:
 
+(defvar vterm-install-buffer-name " *Install vterm"
+  "Name of the buffer used for compiling vterm-module.")
+
 ;;;###autoload
 (defun vterm-module-compile ()
   "This function compiles the vterm-module."
   (interactive)
   (let ((default-directory (file-name-directory (locate-library "vterm"))))
     (unless (file-executable-p (concat default-directory "vterm-module.so" ))
-      (let* ((buffer (get-buffer-create " *Install vterm"))
+      (let* ((buffer (get-buffer-create vterm-install-buffer-name))
              (status (call-process "sh" nil buffer t "-c"
                                    "mkdir -p build;                             \
                                     cd build;                                   \
@@ -21,7 +24,8 @@
                                     make")))
         (if (eq status 0)
             (message "Compilation of emacs-libvterm module succeeded")
-          (message "Compilation of emacs-libvterm module failed"))))))
+          (pop-to-buffer vterm-install-buffer-name)
+          (error "Compilation of emacs-libvterm module failed!"))))))
 
 (when (boundp 'vterm-install)
   (vterm-module-compile))

--- a/vterm.el
+++ b/vterm.el
@@ -13,20 +13,15 @@
   (interactive)
   (let ((default-directory (file-name-directory (locate-library "vterm"))))
     (unless (file-executable-p (concat default-directory "vterm-module.so" ))
-      (let ((buffer (get-buffer-create " *Install vterm")))
-        (pop-to-buffer buffer)
-        (let ((status (call-process "sh" nil buffer t "-c"
-                                    "mkdir -p build;                             \
-                                     cd build;                                   \
-                                     cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; \
-                                     make")))
-          (if (eq status 0)
-              (progn
-                (bury-buffer buffer)
-                (when-let ((window (get-buffer-window buffer)))
-                  (delete-window window))
-                (message "Compilation of emacs-libvterm module succeeded"))
-            (message "Compilation of emacs-libvterm module failed")))))))
+      (let* ((buffer (get-buffer-create " *Install vterm"))
+             (status (call-process "sh" nil buffer t "-c"
+                                   "mkdir -p build;                             \
+                                    cd build;                                   \
+                                    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; \
+                                    make")))
+        (if (eq status 0)
+            (message "Compilation of emacs-libvterm module succeeded")
+          (message "Compilation of emacs-libvterm module failed"))))))
 
 (when (boundp 'vterm-install)
   (vterm-module-compile))


### PR DESCRIPTION
With the asynchronous compilation there would always be an error thrown on the `(require 'vterm-module)`, as there is no `vterm-module` before the compilation is done. Using `call-process` instead of `make-process` makes the compilation is synchronous, so the `(require 'vterm-module)` will only be called once it is finished.

There is also another fix: 38eaf28 (`Add CI`) broke the library's output directory and made `emacs-libvterm` unusable as Emacs was not able to find the library anymore.

I need this PR for integrating `emacs-libvterm` properly into Spacemacs (https://github.com/syl20bnr/spacemacs/pull/11552).

I also removed the `(pop-to-buffer buffer)` and `(delete-window window)`. The user doesn't need to see the compilation and it is awkward when you have your window layout and installing vterm breaks it. 

Now the compilation is completely transparent, to the point that in Spacemacs, since we use lazy-loading, the compilation happens the first time the user runs `vterm` and all he sees is a 1-2s delay before the terminal appears, and a "compilation success" message in the echo area.