### PR TITLE
bind terminal's C-y (yank/paste) to C-c C-y

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -175,6 +175,7 @@ for different shell. "
 (define-key vterm-mode-map [escape]                    #'vterm--self-insert)
 (define-key vterm-mode-map [remap self-insert-command] #'vterm--self-insert)
 (define-key vterm-mode-map [remap yank]                #'vterm-yank)
+(define-key vterm-mode-map (kbd "C-c C-y")             #'vterm--self-insert)
 (define-key vterm-mode-map (kbd "C-c C-c")             #'vterm-send-ctrl-c)
 
 ;; Function keys and most of C- and M- bindings


### PR DESCRIPTION
C-y being bound to Emac's yank, this allows using the terminal's own yank/paste and do combinations such as `C-a C-k` to kill the currently unsent command and `C-c C-y` to restore (paste) it.