### PR TITLE
fix window resize and ignore black at end of line

### DIFF
--- a/vterm-module.h
+++ b/vterm-module.h
@@ -50,6 +50,8 @@ typedef struct Term {
   Cursor cursor;
   char *title;
   bool is_title_changed;
+
+  int width, height;
 } Term;
 
 // Faces

--- a/vterm.el
+++ b/vterm.el
@@ -305,7 +305,7 @@ Feeds the size change to the virtual terminal."
 
 (defun vterm--buffer-line-num()
   "Return the maximum line number."
-  (line-number-at-pos (point-max)))
+  (count-lines (point-min) (point-max)))
 
 (defun vterm--set-title (title)
   "Run the `vterm--set-title-hook' with TITLE as argument."


### PR DESCRIPTION
I think should not call invalidate_terminal() in  term_resize
  when the window heigh decreased, 
  the value of term->invalid_end can't bigger than window height 

maybe this is related to #33 