### PR TITLE
Add env INSIDE_EMACS to vterm

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -103,7 +103,7 @@ for different shell. "
   (setq-local scroll-margin 0)
 
   (add-hook 'window-size-change-functions #'vterm--window-size-change t t)
-  (let ((process-environment (append '("TERM=xterm") process-environment))
+  (let ((process-environment (append '("TERM=xterm" "INSIDE_EMACS=vterm") process-environment))
         (process-adaptive-read-buffering nil))
     (setq vterm--process
           (make-process


### PR DESCRIPTION
# Summary

My zsh config is based on env `INSIDE_EMACS` to alias things like: `vi=emacsclient`