### PR TITLE
Fix: enter/return does not always works

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -169,7 +169,7 @@ for different shell"
 (define-key vterm-mode-map [tab]                       #'vterm--self-insert)
 (define-key vterm-mode-map [backspace]                 #'vterm--self-insert)
 (define-key vterm-mode-map [M-backspace]               #'vterm--self-insert)
-(define-key vterm-mode-map [return]                    #'vterm--self-insert)
+(define-key vterm-mode-map [return]                    #'vterm-send-return)
 (define-key vterm-mode-map [left]                      #'vterm--self-insert)
 (define-key vterm-mode-map [right]                     #'vterm--self-insert)
 (define-key vterm-mode-map [up]                        #'vterm--self-insert)
@@ -227,6 +227,11 @@ for different shell"
   "Sends `C-_' to the libvterm."
   (interactive)
   (vterm-send-key "_" nil nil t))
+
+(defun vterm-send-return ()
+  "Sends C-m to the libvterm."
+  (interactive)
+   (process-send-string vterm--process "\C-m"))
 
 (defun vterm-yank ()
   "Implementation of `yank' (paste) in vterm."


### PR DESCRIPTION
# Issue

https://github.com/akermu/emacs-libvterm/issues/40

# Summary

It's similar function `term-send-return` on https://www.emacswiki.org/emacs/download/multi-term.el.
It works well for me on FZF, Tmux inside Vterm. 