### PR TITLE
fix window resize on emacs27

### DIFF
--- a/elisp.c
+++ b/elisp.c
@@ -123,3 +123,7 @@ void set_title(emacs_env *env, emacs_value string) {
 void vterm_invalidate(emacs_env *env) {
   env->funcall(env, Fvterm_invalidate, 0, NULL);
 }
+bool eq(emacs_env *env, emacs_value e1, emacs_value e2) {
+  emacs_value Qeq = env->funcall(env, Feq, 2, (emacs_value[]){e1, e2});
+  return env->is_not_nil(env, Qeq);
+}

--- a/elisp.h
+++ b/elisp.h
@@ -43,6 +43,7 @@ emacs_value Fget_buffer_window;
 emacs_value Fselected_window;
 emacs_value Fvterm_set_title;
 emacs_value Fvterm_invalidate;
+emacs_value Feq;
 
 // Utils
 void bind_function(emacs_env *env, const char *name, emacs_value Sfun);
@@ -70,5 +71,6 @@ emacs_value get_buffer_window(emacs_env *env);
 emacs_value selected_window(emacs_env *env);
 void set_title(emacs_env *env, emacs_value string);
 void vterm_invalidate(emacs_env *env);
+bool eq(emacs_env *env, emacs_value e1, emacs_value e2);
 
 #endif /* ELISP_H */

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -302,7 +302,7 @@ static void adjust_topline(Term *term, emacs_env *env, long added) {
   emacs_value window = get_buffer_window(env);
   emacs_value swindow = selected_window(env);
 
-  if (swindow == window) {
+  if (eq(env, window, swindow)) {
     if (following) {
       // "Follow" the terminal output
       recenter(env, env->make_integer(
@@ -733,6 +733,7 @@ int emacs_module_init(struct emacs_runtime *ert) {
       env->make_global_ref(env, env->intern(env, "vterm--set-title"));
   Fvterm_invalidate =
       env->make_global_ref(env, env->intern(env, "vterm--invalidate"));
+  Feq = env->make_global_ref(env, env->intern(env, "eq"));
 
   // Exported functions
   emacs_value fun;

--- a/vterm.el
+++ b/vterm.el
@@ -102,7 +102,7 @@ for different shell. "
   (setq-local scroll-conservatively 101)
   (setq-local scroll-margin 0)
 
-  (add-hook 'window-size-change-functions #'vterm--window-size-change t t)
+  (add-hook 'window-size-change-functions #'vterm--window-size-change-function t t)
   (let ((process-environment (append '("TERM=xterm"
                                        "INSIDE_EMACS=vterm"
                                        "LINES"
@@ -265,20 +265,29 @@ Then triggers a redraw from the module."
   (let ((buf (process-buffer process)))
     (run-hook-with-args 'vterm-exit-functions
                         (if (buffer-live-p buf) buf nil))))
-
-(defun vterm--window-size-change (frame)
+(defun vterm--window-size-change-function (frame-or-window)
   "Callback triggered by a size change of the FRAME.
 
-Feeds the size change to the virtual terminal."
-  (dolist (window (window-list frame))
-    (with-current-buffer (window-buffer window)
-      (when (and (processp vterm--process)
-                 (process-live-p vterm--process))
-        (let ((height (window-body-height window))
-              (width (window-body-width window))
-              (inhibit-read-only t))
-          (set-process-window-size vterm--process height width)
-          (vterm--set-size vterm--term height width))))))
+Feeds the size change to the virtual terminal.
+Argument FRAME-OR-WINDOW frame or window."
+  (if (windowp frame-or-window)
+      (vterm--window-size-change frame-or-window)
+    (dolist (window (window-list frame-or-window))
+      (vterm--window-size-change window))))
+
+(defun vterm--window-size-change (window)
+  "Callback triggered by a size change of the widnwo.
+
+Feeds the size change to the virtual terminal.
+Argument WINDOW the window."
+  (with-current-buffer (window-buffer window)
+    (when (and (processp vterm--process)
+               (process-live-p vterm--process))
+      (let ((height (window-body-height window))
+            (width (window-body-width window))
+            (inhibit-read-only t))
+        (set-process-window-size vterm--process height width)
+        (vterm--set-size vterm--term height width)))))
 
 (defun vterm--delete-lines (line-num count &optional delete-whole-line)
   "Delete COUNT lines from LINE-NUM.


### PR DESCRIPTION
get this error on emacs 27
```
Error during redisplay: (vterm--window-size-change #<window 13 on ll ~>) signaled (error "Window is on a different frame")
```
and I see 
```
window-size-change-functions is a variable defined in ‘C source code’.
Its value is nil

  This variable’s value is permanent if it is given a local binding.
  This variable may be risky if used as a file-local variable.

Documentation:
Functions called during redisplay when window sizes have changed.
The value should be a list of functions that take one argument.

Functions specified buffer-locally are called for each window showing
the corresponding buffer if and only if that window has been added or
changed its buffer or its total or body size since the last redisplay.
In this case the window is passed as argument.

Functions specified by the default value are called for each frame if
at least one window on that frame has been added or changed its buffer
or its total or body size since the last redisplay.  In this case the
frame is passed as argument.
```