### PR TITLE
fix recenter for emacs27

### DIFF
--- a/elisp.c
+++ b/elisp.c
@@ -77,6 +77,10 @@ void delete_lines(emacs_env *env, int linenum, int count, bool del_whole_line) {
 void recenter(emacs_env *env, emacs_value pos) {
   env->funcall(env, Frecenter, 1, (emacs_value[]){pos});
 }
+bool eq(emacs_env *env, emacs_value e1, emacs_value e2) {
+  emacs_value Qeq = env->funcall(env, Feq, 2, (emacs_value[]){e1, e2});
+  return env->is_not_nil(env, Qeq);
+}
 
 void forward_char(emacs_env *env, emacs_value n) {
   env->funcall(env, Fforward_char, 1, (emacs_value[]){n});

--- a/elisp.h
+++ b/elisp.h
@@ -43,6 +43,7 @@ emacs_value Fget_buffer_window;
 emacs_value Fselected_window;
 emacs_value Fvterm_set_title;
 emacs_value Fvterm_invalidate;
+emacs_value Feq;
 
 // Utils
 void bind_function(emacs_env *env, const char *name, emacs_value Sfun);
@@ -65,6 +66,7 @@ emacs_value get_hex_color_fg(emacs_env *env, emacs_value face);
 emacs_value get_hex_color_bg(emacs_env *env, emacs_value face);
 emacs_value buffer_line_number(emacs_env *env);
 void recenter(emacs_env *env, emacs_value pos);
+bool eq(emacs_env *env, emacs_value e1, emacs_value e2);
 void forward_char(emacs_env *env, emacs_value n);
 emacs_value get_buffer_window(emacs_env *env);
 emacs_value selected_window(emacs_env *env);

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -302,7 +302,7 @@ static void adjust_topline(Term *term, emacs_env *env, long added) {
   emacs_value window = get_buffer_window(env);
   emacs_value swindow = selected_window(env);
 
-  if (swindow == window) {
+  if (eq(env, window, swindow)) {
     if (following) {
       // "Follow" the terminal output
       recenter(env, env->make_integer(
@@ -733,6 +733,7 @@ int emacs_module_init(struct emacs_runtime *ert) {
       env->make_global_ref(env, env->intern(env, "vterm--set-title"));
   Fvterm_invalidate =
       env->make_global_ref(env, env->intern(env, "vterm--invalidate"));
+  Feq = env->make_global_ref(env, env->intern(env, "eq"));
 
   // Exported functions
   emacs_value fun;


### PR DESCRIPTION
this is necessary for emacs27 

it behave differently  between emacs-libvterm and iterm2 when I use zaw 
in iterm2  when I press ctrl-r it clear all screen and show the zaw candidates ,
but in emacs-libvterm ,the screen is not cleared(recentered) 
```
 git clone  https://github.com/zsh-users/zaw
  echo "source ${PWD}/zaw/zaw.zsh" >> ~/.zshrc
  echo "  bindkey -M emacs '^R' zaw-history  # C-r" >> ~/.zshrc
```
