### PR TITLE
Save and restore point in copy mode.

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -298,7 +298,10 @@ If nil, never delay")
   (if vterm-copy-mode
       (progn                            ;enable vterm-copy-mode
         (use-local-map nil)
-        (vterm-send-stop))
+        (vterm-send-stop)
+        (set (make-local-variable 'vterm-copy-saved-point) (point)))
+    (if vterm-copy-saved-point
+        (goto-char vterm-copy-saved-point))
     (use-local-map vterm-mode-map)
     (vterm-send-start)))
 


### PR DESCRIPTION
This change will save the point when entering copy mode and restore it back once
leaving. This feels much nicer than having the point get out of sync with where
the terminal actually thinks it is.

If the creators of vterm know of a better way I would be glad to figure out how
to implement it, but for now this seems to work fine.