### PR TITLE
Support compilation shell minor mode

### DIFF
--- a/vterm-module.h
+++ b/vterm-module.h
@@ -17,10 +17,17 @@ int plugin_is_GPL_compatible;
 #define MAX(X, Y) ((X) > (Y) ? (X) : (Y))
 #endif
 
+typedef struct LineInfo {
+  char *directory; /* working directory */
+
+} LineInfo;
+
 typedef struct ScrollbackLine {
   size_t cols;
+  LineInfo *info;
   VTermScreenCell cells[];
 } ScrollbackLine;
+
 
 enum {
   VTERM_PROP_CURSOR_BLOCK = VTERM_PROP_CURSORSHAPE_BLOCK,
@@ -67,8 +74,13 @@ typedef struct Term {
   char *elisp_code;
   bool elisp_code_changed;
 
+  /* the size of dirs almost = window height,value = directory of that line */
+  LineInfo **lines;
+  int lines_len;
+
   int width, height;
   int height_resize;
+  bool resizing;
 
   int pty_fd;
 } Term;
@@ -104,6 +116,9 @@ emacs_value Fvterm_set_pty_name(emacs_env *env, ptrdiff_t nargs,
                                 emacs_value args[], void *data);
 emacs_value Fvterm_get_icrnl(emacs_env *env, ptrdiff_t nargs,
                               emacs_value args[], void *data);
+
+emacs_value Fvterm_get_pwd(emacs_env *env, ptrdiff_t nargs,
+                                emacs_value args[], void *data);
 
 int emacs_module_init(struct emacs_runtime *ert);
 

--- a/vterm.el
+++ b/vterm.el
@@ -575,9 +575,11 @@ Argument EVENT process event."
          (inhibit-read-only t))
     (setq width (- width (vterm--get-margin-width)))
     (when (and (processp process)
-               (process-live-p process))
-      (vterm--set-size vterm--term height width))
-    (cons width height)))
+               (process-live-p process)
+               (> width 0)
+               (> height 0))
+      (vterm--set-size vterm--term height width)
+      (cons width height))))
 
 (defun vterm--get-margin-width ()
   "Get margin width of vterm buffer when `display-line-numbers-mode' is enabled."


### PR DESCRIPTION
#56 
vterm enable `compilation-shell-minor-mode` by default.
even you change your working directory, `next-error` `previous-error` still
can find out the corresponding source code.


For `zsh` put this in your `.zshrc`:

```zsh
vterm_prompt() {
    print -Pn "\e]51;A$(pwd)\e\\";
}
PROMPT=$PROMPT'%{$(vterm_prompt)%}'

```
please use `PROMPT`, and do NOT use `chpwd` or `preexec`,
unless you don't want to using `compilation-shell-minor-mode`.
The working directory of lines after a new prompt  need be updated .

For bash 

```bash
vterm_prompt_end(){
  printf "\e]51;A$(pwd)\e\\"
}
PS1=$PS1'$(vterm_prompt_end)'
```

this is ready to be reviewed ,but need more testing before merge.
