### PR TITLE
Add vterm-copy-mode-done command

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -292,6 +292,8 @@ If nil, never delay")
 (defvar vterm-copy-mode-map (make-sparse-keymap)
   "Minor mode map for `vterm-copy-mode'.")
 (define-key vterm-copy-mode-map (kbd "C-c C-t")        #'vterm-copy-mode)
+(define-key vterm-copy-mode-map [return]               #'vterm-copy-mode-done)
+(define-key vterm-copy-mode-map (kbd "RET")            #'vterm-copy-mode-done)
 
 (defvar-local vterm--copy-saved-point nil)
 
@@ -309,6 +311,16 @@ If nil, never delay")
         (goto-char vterm--copy-saved-point))
     (use-local-map vterm-mode-map)
     (vterm-send-start)))
+
+(defun vterm-copy-mode-done ()
+  "Save the active region to the kill ring and save `vterm-copy-mode'."
+  (interactive)
+  (unless vterm-copy-mode
+    (user-error "This command is effective only in vterm-copy-mode"))
+  (unless (region-active-p)
+    (user-error "No region is active"))
+  (kill-ring-save (region-beginning) (region-end))
+  (vterm-copy-mode -1))
 
 (defun vterm--self-insert ()
   "Sends invoking key to libvterm."

--- a/vterm.el
+++ b/vterm.el
@@ -313,7 +313,7 @@ If nil, never delay")
     (vterm-send-start)))
 
 (defun vterm-copy-mode-done ()
-  "Save the active region to the kill ring and save `vterm-copy-mode'."
+  "Save the active region to the kill ring and exit `vterm-copy-mode'."
   (interactive)
   (unless vterm-copy-mode
     (user-error "This command is effective only in vterm-copy-mode"))


### PR DESCRIPTION
On tmux, I was able to copy a selected text and finish the copy mode with enter/return key.

It would be convenient to have the same feature on vterm.el, so I implemented it.