### PR TITLE
Breaking change: Pass sentinel events to exit functions

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -483,12 +483,13 @@ Then triggers a redraw from the module."
         (vterm--write-input vterm--term input)
         (vterm--update vterm--term)))))
 
-(defun vterm--sentinel (process _event)
+(defun vterm--sentinel (process event)
   "Sentinel of vterm PROCESS.
 Argument EVENT process event."
   (let ((buf (process-buffer process)))
     (run-hook-with-args 'vterm-exit-functions
-                        (if (buffer-live-p buf) buf nil))))
+                        (if (buffer-live-p buf) buf nil)
+                        event)))
 
 (defun vterm--window-size-change-26 (frame)
   "Callback triggered by a size change of the FRAME.

--- a/vterm.el
+++ b/vterm.el
@@ -97,7 +97,11 @@ to the terminal anymore."
   :group 'vterm)
 
 (defcustom vterm-exit-functions nil
-  "Shell exit hook.
+  "List of functions called when a vterm process exits.
+
+Each function is called with two arguments: the vterm buffer of
+the process if any, and a string describing the event passed from
+the sentinel.
 
 This hook applies only to new vterms, created after setting this
 value with `add-hook'.


### PR DESCRIPTION
I sometimes want to know if a command run in vterm has successfully exited.

More specifically, I have the following function to run an interactive program inside vterm:

```emacs-lisp
  (defun akirak/run-interactive-shell-command (command &optional name)
    (interactive "s")
    (let ((buffer (generate-new-buffer (or name "*vterm*"))))
      (with-current-buffer buffer
        (let ((vterm-shell command))
          (vterm-mode))
        (pop-to-buffer buffer))))
```

And I want to know the exit code of the command.

Since Emacs provides [sentinels](https://www.gnu.org/software/emacs/manual/html_node/elisp/Sentinels.html) to track status changes in processes, it is technically possible to get the exit status of a process. However, vterm drops event information from sentinels rather than pass it to functions in `vterm-exit-functions`. It would be better to pass the information to the functions so that the user can customize the behavior depending on the exit status. 

I implemented it in this PR. Now functions in `vterm-exit-function` take two arguments, so it would break any existing configuration.

With this PR and the following example configuration, the terminal window closes if and only if the command has successfully exited. If it fails, the window remains open. Also, all sentinel events are logged to the minibuffer and `*Messages*` buffer. 

```emacs-lisp
  (add-hook 'vterm-exit-functions #'akirak/vterm-exit)
  (defun akirak/vterm-exit (buf event)
    (message "%s: %s" (buffer-name) event)
    (when (equal "finished\n" event)
      (quit-window nil (get-buffer-window buf))))
```

How do you think of this feature? I find it useful, but it will not work with existing `vterm-exit-functions` settings, so please merge it with caution.