### PR TITLE
[WIP] Shell Integration  (mark up a shell's output with semantic information )

### DIFF
--- a/vterm-module.h
+++ b/vterm-module.h
@@ -20,6 +20,7 @@ int plugin_is_GPL_compatible;
 typedef struct LineInfo {
   char *directory; /* working directory */
 
+  int prompt_col; /* end column of the prompt,if current line contains prompt */
 } LineInfo;
 
 typedef struct ScrollbackLine {
@@ -27,7 +28,6 @@ typedef struct ScrollbackLine {
   LineInfo *info;
   VTermScreenCell cells[];
 } ScrollbackLine;
-
 
 enum {
   VTERM_PROP_CURSOR_BLOCK = VTERM_PROP_CURSORSHAPE_BLOCK,
@@ -119,6 +119,15 @@ emacs_value Fvterm_get_icrnl(emacs_env *env, ptrdiff_t nargs,
 
 emacs_value Fvterm_get_pwd(emacs_env *env, ptrdiff_t nargs,
                                 emacs_value args[], void *data);
+
+
+emacs_value Fvterm_previous_prompt(emacs_env *env, ptrdiff_t nargs,
+                                   emacs_value args[], void *data);
+emacs_value Fvterm_next_prompt(emacs_env *env, ptrdiff_t nargs,
+                               emacs_value args[], void *data);
+
+emacs_value Fvterm_get_prompt_point(emacs_env *env, ptrdiff_t nargs,
+                                    emacs_value args[], void *data);
 
 int emacs_module_init(struct emacs_runtime *ert);
 

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -19,8 +19,9 @@ int plugin_is_GPL_compatible;
 
 typedef struct LineInfo {
   char *directory; /* working directory */
-
   int prompt_col; /* end column of the prompt,if current line contains prompt */
+  int prompt_begin_col; /* begining column of the prompt,if current line contains prompt */
+  int cmd_col; /* end column of the command,if current line contains the cmd */
 } LineInfo;
 
 typedef struct ScrollbackLine {
@@ -83,6 +84,9 @@ typedef struct Term {
   bool resizing;
 
   int pty_fd;
+
+  int shell_integration;
+
 } Term;
 
 static bool compare_cells(VTermScreenCell *a, VTermScreenCell *b);
@@ -128,6 +132,10 @@ emacs_value Fvterm_next_prompt(emacs_env *env, ptrdiff_t nargs,
 
 emacs_value Fvterm_get_prompt_point(emacs_env *env, ptrdiff_t nargs,
                                     emacs_value args[], void *data);
+emacs_value Fvterm_get_cmd_end_point(emacs_env *env, ptrdiff_t nargs,
+                                     emacs_value args[], void *data);
+emacs_value Fvterm_reset_cursor_point(emacs_env *env, ptrdiff_t nargs,
+                                      emacs_value args[], void *data);
 
 int emacs_module_init(struct emacs_runtime *ert);
 

--- a/vterm.el
+++ b/vterm.el
@@ -336,6 +336,7 @@ This is the value of `next-error-function' in Compilation buffers."
 (define-key vterm-mode-map (kbd "C-SPC")               #'vterm--self-insert)
 (define-key vterm-mode-map (kbd "S-SPC")               #'vterm-send-space)
 (define-key vterm-mode-map (kbd "C-_")                 #'vterm--self-insert)
+(define-key vterm-mode-map (kbd "C-k")                 #'vterm-kill-line)
 (define-key vterm-mode-map (kbd "C-/")                 #'vterm-undo)
 (define-key vterm-mode-map (kbd "M-.")                 #'vterm-send-meta-dot)
 (define-key vterm-mode-map (kbd "M-,")                 #'vterm-send-meta-comma)
@@ -721,7 +722,7 @@ the called functions."
    vterm--term (line-number-at-pos)))
 
 
-(defun vterm-get-prompt-point ()
+(defun vterm--get-prompt-point ()
   "Get the position of the end of current prompt."
   (let (pt)
     (save-excursion
@@ -770,7 +771,7 @@ the called functions."
   (let ((cursor-point (vterm--get-cursor-point))
         (pt (point)))
     (kill-new (vterm-get-input-after-point))
-    (message "%d %d" pt cursor-point)
+    (message "The line is saved to kill ring.")
     (when (eq pt cursor-point)
       (vterm--self-insert))))
 

--- a/vterm.el
+++ b/vterm.el
@@ -778,5 +778,12 @@ the called functions."
     (when (eq pt cursor-point)
       (vterm--self-insert))))
 
+(defun vterm--at-prompt-p ()
+  "Check whether the cursor postion is at shell prompt or not."
+  (let ((pt (point))
+        (term-cursor-pt (vterm--get-cursor-point))
+        (prompt-pt (vterm--get-prompt-point)))
+    (= pt  term-cursor-pt prompt-pt)))
+
 (provide 'vterm)
 ;;; vterm.el ends here

--- a/vterm.el
+++ b/vterm.el
@@ -347,6 +347,7 @@ This is the value of `next-error-function' in Compilation buffers."
 
 (define-key vterm-mode-map (kbd "C-c C-n")             #'vterm-next-prompt)
 (define-key vterm-mode-map (kbd "C-c C-p")             #'vterm-previous-prompt)
+(define-key vterm-mode-map (kbd "C-c C-r")             #'vterm-reset-cursor-point)
 
 (define-key vterm-mode-map (kbd "C-c C-t")             #'vterm-copy-mode)
 
@@ -355,6 +356,7 @@ This is the value of `next-error-function' in Compilation buffers."
 (define-key vterm-copy-mode-map (kbd "C-c C-t")        #'vterm-copy-mode)
 (define-key vterm-copy-mode-map [return]               #'vterm-copy-mode-done)
 (define-key vterm-copy-mode-map (kbd "RET")            #'vterm-copy-mode-done)
+(define-key vterm-copy-mode-map (kbd "C-c C-r")        #'vterm-reset-cursor-point)
 
 (defvar-local vterm--copy-saved-point nil)
 
@@ -758,6 +760,7 @@ the called functions."
 
 (defun vterm-reset-cursor-point ()
   "Make sure the cursor at the right postion."
+  (interactive)
   (vterm--reset-point vterm--term))
 
 (defun vterm--get-cursor-point ()


### PR DESCRIPTION
not finished yet.
and   should be merge after #126 .
there are some refactoring in commit `refactoring  term->dirs and add LineInfo.`  related to #126 
EDIT:
 Want to mark up a shell's output with semantic information about where the prompt ends, where the user-entered command ends.

with `vterm-next-prompt`  and `vterm-previous-prompt`  you can jump to the next/previous prompt position .

And I also want to save the killed line to kill ring when I press `C-k' in the vterm buffer.

