### PR TITLE
Updated directory tracking snippet for zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ For `zsh` put this in your `.zshrc`:
 ```zsh
 if [[ $INSIDE_EMACS = "vterm" ]]; then
     function chpwd() {
-        print -Pn "\e]51;A$(pwd)/\e\\";
+        print -Pn "\e]51;A$(pwd)\e\\";
     }
 fi
 ```

--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ is ansi color 8-15.
 For `zsh` put this in your `.zshrc`:
 
 ```zsh
-function chpwd() {
-    print -Pn "\e]51;A$(pwd)\e\\";
-}
+if [[ $INSIDE_EMACS = "vterm" ]]; then
+    function chpwd() {
+        print -Pn "\e]51;A$(pwd)/\e\\";
+    }
+fi
 ```
 
 For bash there's no real change directory hook, so you have to rewrite the cd


### PR DESCRIPTION
Check if `INSIDE_EMACS` is `vterm` because this code make sense only in vterm.
Also added trailing slash.