### PR TITLE
clear scrollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,14 +168,28 @@ function chpwd() {
 ```
 
 ## Send Elisp Command 
-```sh
+If you want to  clear scrollback and the screen after call to `clear`,
+you can do it like this:
+
+For `zsh` put this in your `.zshrc`:
+```zsh
 if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-    function vi(){
-        echo -n  "\e]51;E(find-file \"$@\")\e\\"
+    alias clear='echo -n  "\e]51;E(vterm-clear-scrollback)\e\\";tput clear'
+fi
+```
+
+For `bash` put this in your `.bashrc`:
+```bash
+if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
+    function clear(){
+        printf  "\e]51;E(vterm-clear-scrollback)\e\\";
+        tput clear;
     }
 fi
-
 ```
+
+By the way `vterm-clear-scrollback` is bind on `C-c C-l`.
+
 ## Related packages
 
 - [vterm-toggle](https://github.com/jixiuf/vterm-toggle): Toggles between a vterm and the current buffer

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -84,8 +84,8 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *user_data);
 
 static void term_redraw(Term *term, emacs_env *env);
 static void term_flush_output(Term *term, emacs_env *env);
-static void term_process_key(Term *term, unsigned char *key, size_t len,
-                             VTermModifier modifier);
+static void term_process_key(Term *term, emacs_env *env, unsigned char *key,
+                             size_t len, VTermModifier modifier);
 static void invalidate_terminal(Term *term, int start_row, int end_row);
 static void refresh_size(Term *term);
 void term_finalize(void *object);

--- a/vterm.el
+++ b/vterm.el
@@ -302,6 +302,7 @@ If nil, never delay")
 (define-key vterm-mode-map (kbd "M-,")                 #'vterm-send-meta-comma)
 (define-key vterm-mode-map (kbd "C-c C-y")             #'vterm--self-insert)
 (define-key vterm-mode-map (kbd "C-c C-c")             #'vterm-send-ctrl-c)
+(define-key vterm-mode-map (kbd "C-c C-l")             #'vterm-clear-scrollback)
 (define-key vterm-mode-map [remap self-insert-command] #'vterm--self-insert)
 
 (define-key vterm-mode-map (kbd "C-c C-t")             #'vterm-copy-mode)
@@ -433,6 +434,11 @@ If nil, never delay")
   "Sends `C-c' to the libvterm."
   (interactive)
   (vterm-send-key "c" nil nil t))
+
+(defun vterm-clear-scrollback ()
+  "Sends `<clear-scrollback>' to the libvterm."
+  (interactive)
+  (vterm-send-key "<clear_scrollback>"))
 
 (defun vterm-undo ()
   "Sends `C-_' to the libvterm."


### PR DESCRIPTION
#165 
libvterm does not support clear scrollback directly.
`vterm-clear-scrollback` is bind on `C-c C-l`.
For `zsh` put this in your `.zshrc`:
```zsh
if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
    alias clear='echo -n  "\e]51;E(vterm-clear-scrollback)\e\\";tput clear'
fi
```

For `bash` put this in your `.bashrc`:
```bash
if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
    function clear(){
        printf  "\e]51;E(vterm-clear-scrollback)\e\\";
        tput clear;
    }
fi
```

