### PR TITLE
Fix shift-space behavior

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -296,6 +296,7 @@ If nil, never delay")
 (define-key vterm-mode-map [remap yank-pop]            #'vterm-yank-pop)
 (define-key vterm-mode-map [remap mouse-yank-primary]  #'vterm-yank-primary)
 (define-key vterm-mode-map (kbd "C-SPC")               #'vterm--self-insert)
+(define-key vterm-mode-map (kbd "S-SPC")               #'vterm-send-space)
 (define-key vterm-mode-map (kbd "C-_")                 #'vterm--self-insert)
 (define-key vterm-mode-map (kbd "C-/")                 #'vterm-undo)
 (define-key vterm-mode-map (kbd "M-.")                 #'vterm-send-meta-dot)
@@ -379,6 +380,11 @@ If nil, never delay")
   "Sends `<tab>' to the libvterm."
   (interactive)
   (vterm-send-key "<tab>"))
+
+(defun vterm-send-space ()
+  "Sends `<space>' to the libvterm."
+  (interactive)
+  (vterm-send-key " "))
 
 (defun vterm-send-backspace ()
   "Sends `<backspace>' to the libvterm."


### PR DESCRIPTION
This PR improves handling of shift-space. I find that I often hold down shift after typing special characters, like `!`. Using `emacs-libvterm`, <kbd>S-SPC</kbd> currently sends an escape sequence that ends up being displayed on the line.

With the changes in this PR, holding shift will send a space normally, like in other terminal programs. macOS's Terminal.app and iTerm2 both do this, so it seems like standard behavior.