### PR TITLE
WIP: add C-\, C-g

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -342,6 +342,8 @@ This is the value of `next-error-function' in Compilation buffers."
 (define-key vterm-mode-map (kbd "C-c C-y")             #'vterm--self-insert)
 (define-key vterm-mode-map (kbd "C-c C-c")             #'vterm-send-ctrl-c)
 (define-key vterm-mode-map (kbd "C-c C-l")             #'vterm-clear-scrollback)
+(define-key vterm-mode-map (kbd "C-\\")                #'vterm-send-ctrl-slash)
+(define-key vterm-mode-map (kbd "C-c C-g")             #'vterm-send-ctrl-g)
 (define-key vterm-mode-map [remap self-insert-command] #'vterm--self-insert)
 
 (define-key vterm-mode-map (kbd "C-c C-t")             #'vterm-copy-mode)
@@ -480,6 +482,14 @@ This is the value of `next-error-function' in Compilation buffers."
   "Sends `C-c' to the libvterm."
   (interactive)
   (vterm-send-key "c" nil nil t))
+
+(defun vterm-send-ctrl-slash ()
+  (interactive)
+  (vterm-send-key "\\" nil nil t))
+
+(defun vterm-send-ctrl-g ()
+  (interactive)
+  (vterm-send-key "g" nil nil t))
 
 (defun vterm-clear-scrollback ()
   "Sends `<clear-scrollback>' to the libvterm."


### PR DESCRIPTION
I find it useful to send <kbd> C-\ </kbd> and <kbd>C-g</kbd> to the terminal, for instance to control tmux and exit from `fzf` completions. This MR adds keybindings to send those key combinations.