### PR TITLE
Separate elisp code that builds external dependency and the rest of elisp code

### DIFF
--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -1,7 +1,6 @@
 ;;; vterm-module-make.el --- make vterm-module in elisp  -*- lexical-binding: t; -*-
 
 (require 'files)
-(require 'term)
 
 (defvar vterm-install-buffer-name " *Install vterm"
   "Name of the buffer used for compiling vterm-module.")

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -1,0 +1,31 @@
+;;; vterm-module-make.el --- make vterm-module in elisp  -*- lexical-binding: t; -*-
+
+(require 'files)
+(require 'term)
+
+(defvar vterm-install-buffer-name " *Install vterm"
+  "Name of the buffer used for compiling vterm-module.")
+
+;;;###autoload
+(defun vterm-module-compile ()
+  "This function compiles the vterm-module."
+  (interactive)
+  (let ((default-directory (file-name-directory (file-truename (locate-library "vterm")))))
+    (unless (file-executable-p (concat default-directory "vterm-module.so" ))
+      (let* ((buffer (get-buffer-create vterm-install-buffer-name))
+             status)
+        (pop-to-buffer vterm-install-buffer-name)
+        (setq status (call-process "sh" nil buffer t "-c"
+                                   "mkdir -p build;                             \
+                                    cd build;                                   \
+                                    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; \
+                                    make") )
+        (if (eq status 0)
+            (message "Compilation of emacs-libvterm module succeeded")
+          (error "Compilation of emacs-libvterm module failed!"))))))
+
+
+(or (require 'vterm-module nil t)
+    (vterm-module-compile))
+
+(provide 'vterm-module-make)

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -22,8 +22,7 @@
     (unless (file-executable-p (concat default-directory "vterm-module.so"))
       (let* ((buffer (get-buffer-create vterm-install-buffer-name)))
         (pop-to-buffer vterm-install-buffer-name)
-        (if (eql 0
-                 (call-process "sh" nil buffer t "-c" make-commands))
+        (if (zerop (call-process "sh" nil buffer t "-c" make-commands))
             (message "Compilation of emacs-libvterm module succeeded")
           (error "Compilation of emacs-libvterm module failed!"))))))
 

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -20,15 +20,12 @@
             ..; \
           make"))
     (unless (file-executable-p (concat default-directory "vterm-module.so"))
-      (let* ((buffer (get-buffer-create vterm-install-buffer-name))
-             status)
+      (let* ((buffer (get-buffer-create vterm-install-buffer-name)))
         (pop-to-buffer vterm-install-buffer-name)
-        (setq status
-              (call-process "sh" nil buffer t "-c" make-commands))
-        (if (eq status 0)
+        (if (eql 0
+                 (call-process "sh" nil buffer t "-c" make-commands))
             (message "Compilation of emacs-libvterm module succeeded")
           (error "Compilation of emacs-libvterm module failed!"))))))
-
 
 (or (require 'vterm-module nil t)
     (vterm-module-compile))

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -10,16 +10,19 @@
 (defun vterm-module-compile ()
   "This function compiles the vterm-module."
   (interactive)
-  (let ((default-directory (file-name-directory (file-truename (locate-library "vterm")))))
-    (unless (file-executable-p (concat default-directory "vterm-module.so" ))
+  (let ((default-directory
+          (file-name-directory (file-truename (locate-library "vterm"))))
+        (make-commands
+         "mkdir -p build; \
+          cd build; \
+          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; \
+          make"))
+    (unless (file-executable-p (concat default-directory "vterm-module.so"))
       (let* ((buffer (get-buffer-create vterm-install-buffer-name))
              status)
         (pop-to-buffer vterm-install-buffer-name)
-        (setq status (call-process "sh" nil buffer t "-c"
-                                   "mkdir -p build;                             \
-                                    cd build;                                   \
-                                    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; \
-                                    make") )
+        (setq status
+              (call-process "sh" nil buffer t "-c" make-commands))
         (if (eq status 0)
             (message "Compilation of emacs-libvterm module succeeded")
           (error "Compilation of emacs-libvterm module failed!"))))))

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -15,7 +15,9 @@
         (make-commands
          "mkdir -p build; \
           cd build; \
-          cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; \
+          cmake \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            ..; \
           make"))
     (unless (file-executable-p (concat default-directory "vterm-module.so"))
       (let* ((buffer (get-buffer-create vterm-install-buffer-name))

--- a/vterm.el
+++ b/vterm.el
@@ -50,6 +50,7 @@
 
 (require 'subr-x)
 (require 'cl-lib)
+(require 'term)
 (require 'color)
 (require 'compile)
 

--- a/vterm.el
+++ b/vterm.el
@@ -45,33 +45,8 @@
 (unless module-file-suffix
   (error "VTerm needs module support. Please compile your Emacs with the --with-modules option!"))
 
-(require 'term)
-
-(defvar vterm-install-buffer-name " *Install vterm"
-  "Name of the buffer used for compiling vterm-module.")
-
-;;;###autoload
-(defun vterm-module-compile ()
-  "This function compiles the vterm-module."
-  (interactive)
-  (let ((default-directory (file-name-directory (file-truename (locate-library "vterm")))))
-    (unless (file-executable-p (concat default-directory "vterm-module.so" ))
-      (let* ((buffer (get-buffer-create vterm-install-buffer-name))
-             status)
-        (pop-to-buffer vterm-install-buffer-name)
-        (setq status (call-process "sh" nil buffer t "-c"
-                                   "mkdir -p build;                             \
-                                    cd build;                                   \
-                                    cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ..; \
-                                    make") )
-        (if (eq status 0)
-            (message "Compilation of emacs-libvterm module succeeded")
-          (error "Compilation of emacs-libvterm module failed!"))))))
-
-
-(unless (require 'vterm-module nil t)
-  (vterm-module-compile)
-  (require 'vterm-module))
+(or (require 'vterm-module nil t)
+    (require 'vterm-module-make)) 
 
 (require 'subr-x)
 (require 'cl-lib)

--- a/vterm.el
+++ b/vterm.el
@@ -46,7 +46,8 @@
   (error "VTerm needs module support. Please compile your Emacs with the --with-modules option!"))
 
 (or (require 'vterm-module nil t)
-    (require 'vterm-module-make)) 
+    (and (require 'vterm-module-make)
+         (require 'vterm-module))) 
 
 (require 'subr-x)
 (require 'cl-lib)


### PR DESCRIPTION
Currently, on each update vterm recompiles the module disregarding the general system settings and also fetches libvterm. This is very annoyng and requires integration of vterm into a system package manager.

When installing from an external package manager, it makes no sense to even have `vterm-module-compile` available unless it is kept aligned with system-wide settings. Keeping it aligned, however, essentially requires patching the package twice: patching command string in elisp, and introducing the same options on a more general level, which is a very unwelcome redundancy.

It's best if elisp build infrastructure can be disregarded completely; for that, `vterm.el` has to be split and all build-related stuff should go to its own elisp module. It is also beneficial due to the fact that external package manager may use emacs to build `vterm-module` without loading any other elisp files.

I isolated the make function, modified its parameters string so that configuring patches, if any, look better (an option per line), replaced `(eq 0)` with `zerop`, and eliminated a variable that does not bring anything to the table. I also explicitly mentioned the `files` dependency because I usually do it.

`vterm-module-make` might nevertheless still need some commented preamble; I'm not aware of what's considered good style here.