### PR TITLE
 Rendered properly when  font resizing and add face vterm-font-default

### DIFF
--- a/elisp.c
+++ b/elisp.c
@@ -86,6 +86,9 @@ emacs_value point(emacs_env *env) { return env->funcall(env, Fpoint, 0, NULL); }
 void set_window_point(emacs_env *env, emacs_value win, emacs_value point) {
   env->funcall(env, Fset_window_point, 2, (emacs_value[]){win, point});
 }
+emacs_value window_body_height(emacs_env *env, emacs_value win) {
+  return env->funcall(env, Fwindow_body_height, 1, (emacs_value[]){win});
+}
 
 bool eq(emacs_env *env, emacs_value e1, emacs_value e2) {
   emacs_value Qeq = env->funcall(env, Feq, 2, (emacs_value[]){e1, e2});

--- a/elisp.h
+++ b/elisp.h
@@ -37,6 +37,7 @@ emacs_value Fgoto_line;
 emacs_value Fdelete_lines;
 emacs_value Frecenter;
 emacs_value Fset_window_point;
+emacs_value Fwindow_body_height;
 emacs_value Fpoint;
 
 emacs_value Fput_text_property;
@@ -70,6 +71,7 @@ void set_cursor_type(emacs_env *env, emacs_value cursor_type);
 void delete_lines(emacs_env *env, int linenum, int count, bool del_whole_line);
 void recenter(emacs_env *env, emacs_value pos);
 void set_window_point(emacs_env *env, emacs_value win, emacs_value point);
+emacs_value window_body_height(emacs_env *env, emacs_value win);
 emacs_value point(emacs_env *env);
 bool eq(emacs_env *env, emacs_value e1, emacs_value e2);
 void forward_char(emacs_env *env, emacs_value n);

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -1129,6 +1129,9 @@ int emacs_module_init(struct emacs_runtime *ert) {
   Frecenter = env->make_global_ref(env, env->intern(env, "recenter"));
   Fset_window_point =
       env->make_global_ref(env, env->intern(env, "set-window-point"));
+  Fwindow_body_height =
+      env->make_global_ref(env, env->intern(env, "window-body-height"));
+
   Fpoint = env->make_global_ref(env, env->intern(env, "point"));
   Fforward_char = env->make_global_ref(env, env->intern(env, "forward-char"));
   Fget_buffer_window_list =

--- a/vterm.el
+++ b/vterm.el
@@ -143,6 +143,12 @@ party to commandeer your editor."
   :type  'boolean
   :group 'vterm)
 
+(defface vterm-font-default
+  `((t :inherit default))
+  "The default font for vterm buffer.
+Monospaced font whihc is fixed idth and height is recommended."
+  :group 'vterm)
+
 (defface vterm-color-default
   `((t :inherit default))
   "The default normal color and bright color.
@@ -234,6 +240,7 @@ If nil, never delay")
 (define-derived-mode vterm-mode fundamental-mode "VTerm"
   "Major mode for vterm buffer."
   (buffer-disable-undo)
+  (face-remap-add-relative 'default 'vterm-font-default)
   (let ((process-environment (append `(,(concat "TERM="
                                                 vterm-term-environment-variable)
                                        "INSIDE_EMACS=vterm"

--- a/vterm.el
+++ b/vterm.el
@@ -249,7 +249,9 @@ If nil, never delay")
     (setq buffer-read-only t)
     (setq-local scroll-conservatively 101)
     (setq-local scroll-margin 0)
-    (setq-local line-spacing nil)
+    (setq-local hscroll-margin 0)
+    (setq-local hscroll-step 1)
+    (setq-local truncate-lines t)
     (setq vterm--process
           (make-process
            :name "vterm"
@@ -598,14 +600,18 @@ Argument BUFFER the terminal buffer."
   (when (buffer-live-p buffer)
     (with-current-buffer buffer
       (let ((inhibit-redisplay t)
-            (inhibit-read-only t))
+            (inhibit-read-only t)
+            (windows (get-buffer-window-list)))
         (setq vterm--redraw-timer nil)
         (when vterm--term
           (when (and (require 'display-line-numbers nil 'noerror)
                      (get-buffer-window buffer t)
                      (ignore-errors (display-line-numbers-update-width)))
             (window--adjust-process-windows))
-          (vterm--redraw vterm--term))))))
+          (vterm--redraw vterm--term)
+          (unless (zerop (window-hscroll))
+            (when (cl-member (selected-window) windows :test #'eq)
+              (set-window-hscroll (selected-window) 0))))))))
 
 ;;;###autoload
 (defun vterm (&optional buffer-name)


### PR DESCRIPTION
1. Can set font for vterm  buffer by custom vterm-font-default .

2. Rendered properly when  font resizing. #162 is related 

3.  `line-spacing' needn't set to nil now.