### PR TITLE
[WIP] Ask which libvterm to use upon compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,18 +72,30 @@ components.
 
 `vterm` can be install with MELPA with `use-package` by adding the following
 lines to your `init.el`:
-
 ```elisp
 (use-package vterm
     :ensure t
+)
+```
+The package will be compiled the first time `vterm` is run. The package will
+ask you if you want to use your system libvterm (that has to be installed
+separately). If you answer `no`, the latest version available will be downloaded
+and used. Another way to use the libvterm available on your system is to set the
+variable `vterm-compile-with-system-libvterm` to `t` before the first
+compilation:
+```elisp
+(use-package vterm
+    :ensure t
+    :init
+    (setq vterm-compile-with-system-libvterm t)
 )
 ```
 
 ## vterm and Ubuntu
 
 Using `vterm` on Ubuntu requires additional steps. The latest LTS version
-(18.04) ships with a version of CMake that is too old for `vterm` and GNU
-Emacs is not compiled with support for dynamical module loading.
+(18.04) ships with a version of CMake that is too old for `vterm` and GNU Emacs
+is not compiled with support for dynamical module loading.
 
 It is possible to install GNU Emacs with module support from Kevin Kelley's PPA.
 The binary in Ubuntu Emacs Lisp PPA is currently broken and leads to segmentation faults

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -2,7 +2,7 @@
 
 (require 'files)
 
-(defvar vterm-install-buffer-name " *Install vterm"
+(defvar vterm-install-buffer-name "*Install vterm*"
   "Name of the buffer used for compiling vterm-module.")
 
 (defcustom vterm-compile-with-system-libvterm nil

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -27,7 +27,10 @@ the system libvterm is used."
                vterm-compile-with-system-libvterm
                (y-or-n-p
                 "Do you want to use the system libvterm? (It has to be installed separately)"))
-              "yes"
+              (progn
+                (setq vterm-compile-with-system-libvterm t) ; If the user says "yes",
+                                                            ; we save their preference
+               "yes")
               "no"))
          (make-commands
           (concat

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -18,7 +18,7 @@ and a local copy from GitHub."
 If the variable vterm-compile-with-system-libvterm is set to t,
 the system libvterm is used."
   (interactive)
-  (let* ((default-directory
+  (let* ((vterm-directory
            (file-name-directory (file-truename (locate-library "vterm"))))
          ;; Ask the user if they want to compile with the version of libvterm
          ;; on the system. It has to be available! (We don't perform checks)
@@ -34,10 +34,11 @@ the system libvterm is used."
               "no"))
          (make-commands
           (concat
+           "cd " vterm-directory ";"
            "mkdir -p build;"
            "cd build;"
-           "cmake" "-DUSE_SYSTEM_LIBVTERM=" compile-with-system-libvterm " "
-           "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "..;"
+           "cmake" " -DUSE_SYSTEM_LIBVTERM=" compile-with-system-libvterm
+           " -DCMAKE_BUILD_TYPE=RelWithDebInfo " "..;"
            "make")))
     (unless (file-executable-p (concat default-directory "vterm-module.so"))
       (let* ((buffer (get-buffer-create vterm-install-buffer-name)))

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -5,19 +5,30 @@
 (defvar vterm-install-buffer-name " *Install vterm"
   "Name of the buffer used for compiling vterm-module.")
 
+(defcustom vterm-compile-with-system-libvterm nil
+  "Compile vterm with the system libvterm instead of downloading
+and a local copy from GitHub."
+  :type  'boolean
+  :group 'vterm)
+
 ;;;###autoload
 (defun vterm-module-compile ()
-  "This function compiles the vterm-module."
+  "This function compiles the vterm-module.
+
+If the variable vterm-compile-with-system-libvterm is set to t,
+the system libvterm is used."
   (interactive)
   (let* ((default-directory
            (file-name-directory (file-truename (locate-library "vterm"))))
          ;; Ask the user if they want to compile with the version of libvterm
          ;; on the system. It has to be available! (We don't perform checks)
          (compile-with-system-libvterm
-          (if (y-or-n-p
-                   "Do you want to use the system libvterm? (It has to be installed)")
+          (if (or
+               vterm-compile-with-system-libvterm
+               (y-or-n-p
+                "Do you want to use the system libvterm? (It has to be installed separately)"))
               "yes"
-              "no"))
+            "no"))
          (make-commands
           (concat
            "mkdir -p build;"

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -9,15 +9,22 @@
 (defun vterm-module-compile ()
   "This function compiles the vterm-module."
   (interactive)
-  (let ((default-directory
-          (file-name-directory (file-truename (locate-library "vterm"))))
-        (make-commands
-         "mkdir -p build; \
-          cd build; \
-          cmake \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            ..; \
-          make"))
+  (let* ((default-directory
+           (file-name-directory (file-truename (locate-library "vterm"))))
+         ;; Ask the user if they want to compile with the version of libvterm
+         ;; on the system. It has to be available! (We don't perform checks)
+         (compile-with-system-libvterm
+          (if (y-or-n-p
+                   "Do you want to use the system libvterm? (It has to be installed)")
+              "yes"
+              "no"))
+         (make-commands
+          (concat
+           "mkdir -p build;"
+           "cd build;"
+           "cmake" "-DUSE_SYSTEM_LIBVTERM=" compile-with-system-libvterm " "
+           "-DCMAKE_BUILD_TYPE=RelWithDebInfo" "..;"
+           "make")))
     (unless (file-executable-p (concat default-directory "vterm-module.so"))
       (let* ((buffer (get-buffer-create vterm-install-buffer-name)))
         (pop-to-buffer vterm-install-buffer-name)

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -28,7 +28,7 @@ the system libvterm is used."
                (y-or-n-p
                 "Do you want to use the system libvterm? (It has to be installed separately)"))
               "yes"
-            "no"))
+              "no"))
          (make-commands
           (concat
            "mkdir -p build;"


### PR DESCRIPTION
`vterm-module-make`  ignores the (possible) existence of a system `libvterm`. Some users may prefer to use the `libvterm` provided by their distribution. With this PR, users will be asked which `libvterm` they want to use. 

This PR requires more tests before being merged.