### PR TITLE
Substitute switch-to-buffer with pop-to-buffer-same-window

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -649,7 +649,7 @@ Argument BUFFER the terminal buffer."
   (let ((buffer (generate-new-buffer (or buffer-name "vterm"))))
     (with-current-buffer buffer
       (vterm-mode))
-    (switch-to-buffer buffer)))
+    (pop-to-buffer-same-window buffer)))
 
 ;;;###autoload
 (defun vterm-other-window ()

--- a/vterm.el
+++ b/vterm.el
@@ -644,7 +644,10 @@ Argument BUFFER the terminal buffer."
 
 ;;;###autoload
 (defun vterm (&optional buffer-name)
-  "Create a new vterm."
+  "Create a new vterm.
+
+If called with an argument ARG, the name of the new buffer will
+be set to ARG, otherwise it will be `vterm'"
   (interactive)
   (let ((buffer (generate-new-buffer (or buffer-name "vterm"))))
     (with-current-buffer buffer
@@ -652,13 +655,15 @@ Argument BUFFER the terminal buffer."
     (pop-to-buffer-same-window buffer)))
 
 ;;;###autoload
-(defun vterm-other-window ()
-  "Create a new vterm."
+(defun vterm-other-window (&optional buffer-name)
+  "Create a new vterm in another window.
+
+If called with an argument ARG, the name of the new buffer will
+be set to ARG, otherwise it will be `vterm'"
   (interactive)
-  (let ((buffer (generate-new-buffer "vterm")))
+  (let ((buffer (generate-new-buffer (or buffer-name "vterm"))))
     (with-current-buffer buffer
       (vterm-mode))
-
     (pop-to-buffer buffer)))
 
 (defun vterm--flush-output (output)


### PR DESCRIPTION
The usage of switch-to-buffer in packages is discouraged. See, https://debbugs.gnu.org/cgi/bugreport.cgi?bug=28645#25

This commits addresses issue #180 and should avoid the point to jump around unexpectedly when new buffers are opened in unusual ways or with unusual configurations.
