### PR TITLE
Fix some packaging issues

### DIFF
--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -54,7 +54,4 @@ the executable."
               (message "Compilation of `emacs-libvterm' module succeeded")
             (error "Compilation of `emacs-libvterm' module failed!")))))))
 
-(or (require 'vterm-module nil t)
-    (vterm-module-compile))
-
 (provide 'vterm-module-make)

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -46,12 +46,11 @@ the executable."
              vterm-module-cmake-args
              " ..; \
              make; \
-             cd -")))
-      (unless (file-executable-p (concat default-directory "vterm-module.so"))
-        (let* ((buffer (get-buffer-create vterm-install-buffer-name)))
-          (pop-to-buffer vterm-install-buffer-name)
-          (if (zerop (call-process "sh" nil buffer t "-c" make-commands))
-              (message "Compilation of `emacs-libvterm' module succeeded")
-            (error "Compilation of `emacs-libvterm' module failed!")))))))
+             cd -"))
+           (buffer (get-buffer-create vterm-install-buffer-name)))
+      (pop-to-buffer buffer)
+      (if (zerop (call-process "sh" nil buffer t "-c" make-commands))
+          (message "Compilation of `emacs-libvterm' module succeeded")
+        (error "Compilation of `emacs-libvterm' module failed!")))))
 
 (provide 'vterm-module-make)

--- a/vterm.el
+++ b/vterm.el
@@ -304,10 +304,6 @@ variable `next-error-function', so we should call this function in
 This is the value of `next-error-function' in Compilation buffers."
   (interactive "p")
   (let* ((pt (point))
-         (msg (compilation-next-error (or n 1) nil
-				                      (or compilation-current-error
-					                      compilation-messages-start
-					                      (point-min))))
          (default-directory default-directory)
          (pwd (vterm--get-pwd)))
     (when pwd
@@ -691,7 +687,7 @@ Argument EVENT process event."
         (kill-buffer buf))
     ))
 
-(defun vterm--text-scale-mode (&optional argv)
+(defun vterm--text-scale-mode (&optional _argv)
   "fix `line-number' height for scaled text"
   (and text-scale-mode
        (equal major-mode 'vterm-mode)

--- a/vterm.el
+++ b/vterm.el
@@ -51,6 +51,8 @@
   (vterm-module-compile)
   (require 'vterm-module))
 
+(declare-function display-line-numbers-update-width "display-line-numbers")
+
 (require 'subr-x)
 (require 'cl-lib)
 (require 'term)

--- a/vterm.el
+++ b/vterm.el
@@ -46,9 +46,10 @@
   (error "VTerm needs module support. Please compile your Emacs
   with the --with-modules option!"))
 
-(or (require 'vterm-module nil t)
-    (and (require 'vterm-module-make)
-         (require 'vterm-module)))
+(unless (require 'vterm-module nil t)
+  (require 'vterm-module-make)
+  (vterm-module-compile)
+  (require 'vterm-module))
 
 (require 'subr-x)
 (require 'cl-lib)

--- a/vterm.el
+++ b/vterm.el
@@ -322,12 +322,6 @@ This is the value of `next-error-function' in Compilation buffers."
                      ,(string-prefix-p "M-" key)
                      ,(string-prefix-p "C-" key))))
 
-(defmacro vterm-bind-key (key)
-  (declare (indent defun)
-           (doc-string 3))
-  `(define-key vterm-mode-map (kbd ,key)
-     #',(intern (format "vterm-send-%s"  key))))
-
 (mapc (lambda (key)
         (eval `(vterm-define-key ,key)))
       (cl-loop for prefix in '("C-" "M-")
@@ -348,7 +342,8 @@ This is the value of `next-error-function' in Compilation buffers."
                  unless (member key exceptions)
                  collect key))
   (mapc (lambda (key)
-          (eval `(vterm-bind-key ,key)))
+          (define-key vterm-mode-map (kbd key)
+            (intern (format "vterm-send-%s" key))))
         (cl-loop for prefix in '("C-" "M-")
                  append (cl-loop for char from ?a to ?z
                                  for key = (format "%s%c" prefix char)


### PR DESCRIPTION
Hi, I'm using this package as a submodule (using borg package manager rather than installing via package.el) and found some issues. See each commit.

- Do not compile vterm when loading vterm-module-make
I don't think compilation should run when just loading vterm-module-make. Explicitly calling compile from vterm.el makes more sense.

- Always compile when calling vterm-module-compile
If you have an outdated vterm-module.so, you'll want to be able to recompile it. `(require 'vterm-module nil t)` is already essentially the same check. I want to call vterm-module-compile whenever I update this submodule, but currently it does nothing if vterm-module.so exists.

Then I went loose and fixed byte compilation:
- Add declarations to quiet byte compiler
- Remove unused code
- Inline vterm-bind-key (not needed, but this was an odd macro - am I missing something?)
- Evaluate parts during compilation
