### PR TITLE
Update build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if(USE_SYSTEM_LIBVTERM)
 else()
   ExternalProject_add(libvterm
     GIT_REPOSITORY https://github.com/neovim/libvterm.git
-    GIT_TAG 89675ffdda615ffc3f29d1c47a933f4f44183364
+    GIT_TAG 65dbda3ed214f036ee799d18b2e693a833a0e591
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${LIBVTERM_BUILD_COMMAND} "CFLAGS='-fPIC'"
     BUILD_IN_SOURCE ON

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,11 @@ else()
     BUILD_IN_SOURCE ON
     INSTALL_COMMAND "")
 
+  find_program(LIBTOOL NAMES libtool glibtool)
+  if(NOT LIBTOOL)
+    message(FATAL_ERROR "libtool not found. Please install libtool")
+  endif()
+
   ExternalProject_Get_property(libvterm SOURCE_DIR)
 
   set(LIBVTERM_INCLUDE_DIR ${SOURCE_DIR}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,12 @@ set_target_properties(vterm-module PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}
   )
 
+# Set RelWithDebInfo as default build type
+if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "No build type selected, defaulting to RelWithDebInfo")
+  set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Build type (default RelWithDebInfo)" FORCE)
+endif()
+
 # Look for the header file.
 option(USE_SYSTEM_LIBVTERM "Use system libvterm instead of the vendored version." OFF)
 
@@ -38,6 +44,11 @@ if(USE_SYSTEM_LIBVTERM)
     message(FATAL_ERROR "libvterm not found")
   endif()
 else()
+  find_program(LIBTOOL NAMES libtool glibtool)
+  if(NOT LIBTOOL)
+    message(FATAL_ERROR "libtool not found. Please install libtool")
+  endif()
+
   ExternalProject_add(libvterm
     GIT_REPOSITORY https://github.com/neovim/libvterm.git
     GIT_TAG 65dbda3ed214f036ee799d18b2e693a833a0e591
@@ -45,11 +56,6 @@ else()
     BUILD_COMMAND ${LIBVTERM_BUILD_COMMAND} "CFLAGS='-fPIC'"
     BUILD_IN_SOURCE ON
     INSTALL_COMMAND "")
-
-  find_program(LIBTOOL NAMES libtool glibtool)
-  if(NOT LIBTOOL)
-    message(FATAL_ERROR "libtool not found. Please install libtool")
-  endif()
 
   ExternalProject_Get_property(libvterm SOURCE_DIR)
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ rendering of colors in some systems.
 If set to `t`, buffers are killed when the associated process is terminated
 (for example, by logging out the shell).
 
+## `vterm-module-compilation-flags`
+
+Compilation flags to be given to CMake when compiling the module. This string is
+directly passed to CMake, so it uses the same syntax. At the moment, it main use
+is for compiling vterm using the system libvterm instead of the one downloaded
+from GitHub.
+
 ## Keybindings
 
 If you want a key to be sent to the terminal, bind it to `vterm--self-insert`,

--- a/README.md
+++ b/README.md
@@ -212,12 +212,13 @@ rendering of colors in some systems.
 If set to `t`, buffers are killed when the associated process is terminated
 (for example, by logging out the shell).
 
-## `vterm-module-compilation-flags`
+## `vterm-module-cmake-args
 
-Compilation flags to be given to CMake when compiling the module. This string is
-directly passed to CMake, so it uses the same syntax. At the moment, it main use
-is for compiling vterm using the system libvterm instead of the one downloaded
-from GitHub.
+Compilation flags and arguments to be given to CMake when compiling the module.
+This string is directly passed to CMake, so it uses the same syntax. At the
+moment, it main use is for compiling vterm using the system libvterm instead of
+the one downloaded from GitHub. You can find all the arguments and flags
+available with `cmake -LA` in the build directory.
 
 ## Keybindings
 

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -2,7 +2,7 @@
 
 (require 'files)
 
-(defcustom vterm-module-custom-compilation-flags ""
+(defcustom vterm-module-compilation-flags ""
   "Flags given to CMake to compile vterm-module.
 
 Currently, the flags available are:
@@ -43,7 +43,7 @@ the executable."
              cd build; \
              cmake \
              -DCMAKE_BUILD_TYPE=RelWithDebInfo "
-            vterm-module-custom-compilation-flags
+            vterm-module-compilation-flags
             " ..; \
              make; \
              cd -"

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -2,7 +2,7 @@
 
 (require 'files)
 
-(defvar vterm-install-buffer-name " *Install vterm"
+(defvar vterm-install-buffer-name " *Install vterm* "
   "Name of the buffer used for compiling vterm-module.")
 
 (defun vterm-module--cmake-is-available ()

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -2,10 +2,11 @@
 
 (require 'files)
 
-(defcustom vterm-module-compilation-flags ""
-  "Flags given to CMake to compile vterm-module.
+(defcustom vterm-module-cmake-args ""
+  "Arguments given to CMake to compile vterm-module.
 
-Currently, the flags available are:
+Currently, vterm defines the following flags (in addition to the
+ones already available in CMake):
 
 `USE_SYSTEM_LIBVTERM'. Set it to `yes' to use the version of
 libvterm installed on your system.
@@ -36,18 +37,16 @@ the executable."
     (let* ((vterm-directory
             (shell-quote-argument
              (file-name-directory (file-truename (locate-library "vterm")))))
-          (make-commands
-           (concat
-            "cd " vterm-directory "; \
+           (make-commands
+            (concat
+             "cd " vterm-directory "; \
              mkdir -p build; \
              cd build; \
-             cmake \
-             -DCMAKE_BUILD_TYPE=RelWithDebInfo "
-            vterm-module-compilation-flags
-            " ..; \
+             cmake "
+             vterm-module-cmake-args
+             " ..; \
              make; \
-             cd -"
-            )))
+             cd -")))
       (unless (file-executable-p (concat default-directory "vterm-module.so"))
         (let* ((buffer (get-buffer-create vterm-install-buffer-name)))
           (pop-to-buffer vterm-install-buffer-name)

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -45,7 +45,8 @@ the executable."
              -DCMAKE_BUILD_TYPE=RelWithDebInfo "
             vterm-module-custom-compilation-flags
             " ..; \
-             make"
+             make; \
+             cd -"
             )))
       (unless (file-executable-p (concat default-directory "vterm-module.so"))
         (let* ((buffer (get-buffer-create vterm-install-buffer-name)))

--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -5,10 +5,20 @@
 (defvar vterm-install-buffer-name " *Install vterm"
   "Name of the buffer used for compiling vterm-module.")
 
+(defun vterm-module--cmake-is-available ()
+  "Return t if cmake is available.
+CMake is needed to build vterm, here we check that we can find
+the executable."
+
+  (unless (executable-find "cmake")
+    (error "Vterm needs CMake to be compiled. Please, install CMake"))
+  t)
+
 ;;;###autoload
 (defun vterm-module-compile ()
   "This function compiles the vterm-module."
   (interactive)
+  (when (vterm-module--cmake-is-available)
   (let ((default-directory
           (file-name-directory (file-truename (locate-library "vterm"))))
         (make-commands
@@ -23,7 +33,7 @@
         (pop-to-buffer vterm-install-buffer-name)
         (if (zerop (call-process "sh" nil buffer t "-c" make-commands))
             (message "Compilation of emacs-libvterm module succeeded")
-          (error "Compilation of emacs-libvterm module failed!"))))))
+          (error "Compilation of emacs-libvterm module failed!")))))))
 
 (or (require 'vterm-module nil t)
     (vterm-module-compile))


### PR DESCRIPTION
This PR implements the improvements discussed in #253 and #240. Namely:
1. By default, vterm uses libvterm pulled from GitHub, now updated to 0.1.3
2. Users can change this behavior by customizing the variable `vterm-module-compilation-flags`
3. We check that `cmake` is available before compiling. If it is not available, we throw an error
4. We check that libtool is available (during compile-time), if not, we inform the user
5. We implement a workaround to avoid changing the `default-directory`, "fixing" #243 

If this PR is merged, #240 and #253 will be closed (without being merged).

@fbergroth, are you interested in reviewing this PR? 
