### PR TITLE
This commit fixes the newlines when copied and pasted.

### DIFF
--- a/elisp.c
+++ b/elisp.c
@@ -58,7 +58,6 @@ void add_text_properties(emacs_env *env, emacs_value string,
                (emacs_value[]){start, end, property, string});
 }
 
-
 void erase_buffer(emacs_env *env) { env->funcall(env, Ferase_buffer, 0, NULL); }
 
 void insert(emacs_env *env, emacs_value string) {

--- a/elisp.c
+++ b/elisp.c
@@ -49,6 +49,16 @@ void put_text_property(emacs_env *env, emacs_value string, emacs_value property,
                (emacs_value[]){start, end, property, value, string});
 }
 
+void add_text_properties(emacs_env *env, emacs_value string,
+                         emacs_value property) {
+  emacs_value start = env->make_integer(env, 0);
+  emacs_value end = length(env, string);
+
+  env->funcall(env, Fadd_text_properties, 4,
+               (emacs_value[]){start, end, property, string});
+}
+
+
 void erase_buffer(emacs_env *env) { env->funcall(env, Ferase_buffer, 0, NULL); }
 
 void insert(emacs_env *env, emacs_value string) {

--- a/elisp.h
+++ b/elisp.h
@@ -25,7 +25,7 @@ emacs_value Qhbar;
 emacs_value Qcursor_type;
 emacs_value Qemacs_major_version;
 emacs_value Qvterm_line_wrap;
-emacs_value Qrear_nonsticky; 
+emacs_value Qrear_nonsticky;
 
 // Emacs functions
 emacs_value Fsymbol_value;
@@ -45,7 +45,7 @@ emacs_value Fwindow_body_height;
 emacs_value Fpoint;
 
 emacs_value Fput_text_property;
-emacs_value Fadd_text_properties; 
+emacs_value Fadd_text_properties;
 emacs_value Fset;
 emacs_value Fvterm_flush_output;
 emacs_value Fget_buffer_window_list;

--- a/elisp.h
+++ b/elisp.h
@@ -24,6 +24,8 @@ emacs_value Qbar;
 emacs_value Qhbar;
 emacs_value Qcursor_type;
 emacs_value Qemacs_major_version;
+emacs_value Qvterm_line_wrap;
+emacs_value Qrear_nonsticky; 
 
 // Emacs functions
 emacs_value Fsymbol_value;
@@ -43,6 +45,7 @@ emacs_value Fwindow_body_height;
 emacs_value Fpoint;
 
 emacs_value Fput_text_property;
+emacs_value Fadd_text_properties; 
 emacs_value Fset;
 emacs_value Fvterm_flush_output;
 emacs_value Fget_buffer_window_list;
@@ -64,6 +67,8 @@ emacs_value list(emacs_env *env, emacs_value elements[], ptrdiff_t len);
 emacs_value nth(emacs_env *env, int idx, emacs_value list);
 void put_text_property(emacs_env *env, emacs_value string, emacs_value property,
                        emacs_value value);
+void add_text_properties(emacs_env *env, emacs_value string,
+                         emacs_value property);
 void erase_buffer(emacs_env *env);
 void insert(emacs_env *env, emacs_value string);
 void goto_char(emacs_env *env, int pos);

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -258,7 +258,7 @@ static void refresh_lines(Term *term, emacs_env *env, int start_row,
   int offset = 0;
   for (i = start_row; i < end_row; i++) {
 
-    int newline = 0; 
+    int newline = 0;
     for (j = 0; j < end_col; j++) {
       fetch_cell(term, i, j, &cell);
 
@@ -295,15 +295,13 @@ static void refresh_lines(Term *term, emacs_env *env, int start_row,
       }
     }
 
-
-    if(!newline) { 
+    if (!newline) {
       emacs_value text = render_text(env, term, buffer, length, &lastCell);
       insert(env, text);
       length = 0;
       text = render_fake_newline(env, term, buffer, length, &lastCell);
       insert(env, text);
     }
-    
   }
   emacs_value text = render_text(env, term, buffer, length, &lastCell);
   insert(env, text);
@@ -674,19 +672,16 @@ static emacs_value render_fake_newline(emacs_env *env, Term *term, char *buffer,
 
   emacs_value text;
   text = env->make_string(env, "\n", 1);
-  
+
   emacs_value properties;
 
   properties =
-    list(env,
-         (emacs_value[]){Qvterm_line_wrap, Qt, Qrear_nonsticky, Qt}, 
-         4);
+      list(env, (emacs_value[]){Qvterm_line_wrap, Qt, Qrear_nonsticky, Qt}, 4);
 
   add_text_properties(env, text, properties);
 
-  return text; 
+  return text;
 }
-
 
 static emacs_value color_to_rgb_string(emacs_env *env, Term *term,
                                        VTermColor *color) {
@@ -1160,8 +1155,10 @@ int emacs_module_init(struct emacs_runtime *ert) {
   Qextend = env->make_global_ref(env, env->intern(env, ":extend"));
   Qemacs_major_version =
       env->make_global_ref(env, env->intern(env, "emacs-major-version"));
-  Qvterm_line_wrap = env->make_global_ref(env, env->intern(env, "vterm-line-wrap"));
-  Qrear_nonsticky = env->make_global_ref(env, env->intern(env, "rear-nonsticky"));
+  Qvterm_line_wrap =
+      env->make_global_ref(env, env->intern(env, "vterm-line-wrap"));
+  Qrear_nonsticky =
+      env->make_global_ref(env, env->intern(env, "rear-nonsticky"));
 
   Qface = env->make_global_ref(env, env->intern(env, "font-lock-face"));
   Qbox = env->make_global_ref(env, env->intern(env, "box"));
@@ -1246,7 +1243,6 @@ int emacs_module_init(struct emacs_runtime *ert) {
   fun = env->make_function(env, 1, 1, Fvterm_reset_cursor_point,
                            "Reset cursor postion.", NULL);
   bind_function(env, "vterm--reset-point", fun);
-
 
   fun = env->make_function(env, 1, 1, Fvterm_get_icrnl,
                            "Gets the icrnl state of the pty", NULL);

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -299,7 +299,7 @@ static void refresh_lines(Term *term, emacs_env *env, int start_row,
       emacs_value text = render_text(env, term, buffer, length, &lastCell);
       insert(env, text);
       length = 0;
-      text = render_fake_newline(env, term, buffer, length, &lastCell);
+      text = render_fake_newline(env, term);
       insert(env, text);
     }
   }
@@ -667,8 +667,7 @@ static emacs_value render_text(emacs_env *env, Term *term, char *buffer,
   return text;
 }
 
-static emacs_value render_fake_newline(emacs_env *env, Term *term, char *buffer,
-                                       int len, VTermScreenCell *cell) {
+static emacs_value render_fake_newline(emacs_env *env, Term *term) {
 
   emacs_value text;
   text = env->make_string(env, "\n", 1);

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -257,6 +257,8 @@ static void refresh_lines(Term *term, emacs_env *env, int start_row,
 
   int offset = 0;
   for (i = start_row; i < end_row; i++) {
+
+    int newline = 0; 
     for (j = 0; j < end_col; j++) {
       fetch_cell(term, i, j, &cell);
 
@@ -270,6 +272,9 @@ static void refresh_lines(Term *term, emacs_env *env, int start_row,
       if (cell.chars[0] == 0) {
         if (is_eol(term, end_col, i, j)) {
           /* This cell is EOL if this and every cell to the right is black */
+          buffer[length] = '\n';
+          length++;
+          newline = 1;
           break;
         }
         buffer[length] = ' ';
@@ -290,8 +295,15 @@ static void refresh_lines(Term *term, emacs_env *env, int start_row,
       }
     }
 
-    buffer[length] = '\n';
-    length++;
+
+    if(!newline) { 
+      emacs_value text = render_text(env, term, buffer, length, &lastCell);
+      insert(env, text);
+      length = 0;
+      text = render_fake_newline(env, term, buffer, length, &lastCell);
+      insert(env, text);
+    }
+    
   }
   emacs_value text = render_text(env, term, buffer, length, &lastCell);
   insert(env, text);
@@ -656,6 +668,25 @@ static emacs_value render_text(emacs_env *env, Term *term, char *buffer,
 
   return text;
 }
+
+static emacs_value render_fake_newline(emacs_env *env, Term *term, char *buffer,
+                                       int len, VTermScreenCell *cell) {
+
+  emacs_value text;
+  text = env->make_string(env, "\n", 1);
+  
+  emacs_value properties;
+
+  properties =
+    list(env,
+         (emacs_value[]){Qvterm_line_wrap, Qt, Qrear_nonsticky, Qt}, 
+         4);
+
+  add_text_properties(env, text, properties);
+
+  return text; 
+}
+
 
 static emacs_value color_to_rgb_string(emacs_env *env, Term *term,
                                        VTermColor *color) {
@@ -1129,6 +1160,8 @@ int emacs_module_init(struct emacs_runtime *ert) {
   Qextend = env->make_global_ref(env, env->intern(env, ":extend"));
   Qemacs_major_version =
       env->make_global_ref(env, env->intern(env, "emacs-major-version"));
+  Qvterm_line_wrap = env->make_global_ref(env, env->intern(env, "vterm-line-wrap"));
+  Qrear_nonsticky = env->make_global_ref(env, env->intern(env, "rear-nonsticky"));
 
   Qface = env->make_global_ref(env, env->intern(env, "font-lock-face"));
   Qbox = env->make_global_ref(env, env->intern(env, "box"));
@@ -1146,6 +1179,8 @@ int emacs_module_init(struct emacs_runtime *ert) {
   Fgoto_char = env->make_global_ref(env, env->intern(env, "goto-char"));
   Fput_text_property =
       env->make_global_ref(env, env->intern(env, "put-text-property"));
+  Fadd_text_properties =
+      env->make_global_ref(env, env->intern(env, "add-text-properties"));
   Fset = env->make_global_ref(env, env->intern(env, "set"));
   Fvterm_flush_output =
       env->make_global_ref(env, env->intern(env, "vterm--flush-output"));

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -90,6 +90,8 @@ static bool compare_cells(VTermScreenCell *a, VTermScreenCell *b);
 static bool is_key(unsigned char *key, size_t len, char *key_description);
 static emacs_value render_text(emacs_env *env, Term *term, char *string,
                                int len, VTermScreenCell *cell);
+static emacs_value render_fake_newline(emacs_env *env, Term *term, char *string,
+                                       int len, VTermScreenCell *cell);
 static emacs_value color_to_rgb_string(emacs_env *env, Term *term,
                                        VTermColor *color);
 

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -90,8 +90,7 @@ static bool compare_cells(VTermScreenCell *a, VTermScreenCell *b);
 static bool is_key(unsigned char *key, size_t len, char *key_description);
 static emacs_value render_text(emacs_env *env, Term *term, char *string,
                                int len, VTermScreenCell *cell);
-static emacs_value render_fake_newline(emacs_env *env, Term *term, char *string,
-                                       int len, VTermScreenCell *cell);
+static emacs_value render_fake_newline(emacs_env *env, Term *term); 
 static emacs_value color_to_rgb_string(emacs_env *env, Term *term,
                                        VTermColor *color);
 


### PR DESCRIPTION
This commit fixes up the newlines that were inserted for wrapping using the same
approach as term.el does. It does so by adding a property to the '\n' chars that
were inserted as a result of wrapping the terminal. When killing a region text
will be passed through the filter-buffer-substring-function
vterm--remove-fake-newlines removing the wrapped new lines by looking for the
'vterm-line-wrap property and removing the char that corresponds.

If this change set is not up to project standards please work with me to correct
any issues you find.