### PR TITLE
vterm-copy-mode-done copies the line if there is no region

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -433,13 +433,16 @@ This is the value of `next-error-function' in Compilation buffers."
     (vterm-send-start)))
 
 (defun vterm-copy-mode-done ()
-  "Save the active region to the kill ring and exit `vterm-copy-mode'."
+  "Save the active region or line to the kill ring and exit `vterm-copy-mode'."
   (interactive)
   (unless vterm-copy-mode
     (user-error "This command is effective only in vterm-copy-mode"))
-  (unless (region-active-p)
-    (user-error "No region is active"))
-  (kill-ring-save (region-beginning) (region-end))
+  (save-excursion
+    (unless (region-active-p)
+      (beginning-of-line)
+      (set-mark (point))
+      (end-of-line))
+    (kill-ring-save (region-beginning) (region-end)))
   (vterm-copy-mode -1))
 
 (defun vterm--self-insert ()


### PR DESCRIPTION
Improvements:
- Easier to copy a full line
- Consistent way of exiting vterm-copy-mode
- Still works the same on regions

How the code works:
- If the region is not set then make the current line the region and proceeds from there.
- save-excursion puts the cursor back where it was after setting the region