### PR TITLE
Cleanup code to reduce linter/compiler errors

### DIFF
--- a/vterm-module.h
+++ b/vterm-module.h
@@ -20,7 +20,8 @@ int plugin_is_GPL_compatible;
 typedef struct LineInfo {
   char *directory; /* working directory */
 
-  int prompt_col; /* end column of the prompt,if current line contains prompt */
+  int prompt_col; /* end column of the prompt, if the current line contains the
+                   * prompt */
 } LineInfo;
 
 typedef struct ScrollbackLine {
@@ -74,7 +75,7 @@ typedef struct Term {
   char *elisp_code;
   bool elisp_code_changed;
 
-  /* the size of dirs almost = window height,value = directory of that line */
+  /* the size of dirs almost = window height, value = directory of that line */
   LineInfo **lines;
   int lines_len;
 


### PR DESCRIPTION
In this PR I add [makem.sh](https://github.com/alphapapa/makem.sh) to this project. 

`makem` provides a simple way to use GitHub actions to test and lint the code in a sandboxed environment. At the moment, I envision using `makem` for linting, but it would be great if we added tests too. Notice, this package would not be accepted in MELPA in the current state. 

It is necessary that we improve the documentation of the code, and I hope that `makem` will help us in this direction. I am working on improving the documentation on the elisp side. At the moment, I am just trying to have a minimum of documentation for everything, but I am planning to go deeper and have more comprehensive docstrings.

I think that from now on we shouldn't merge PR if they add features that are not thoroughly documented. 