### PR TITLE
[add] Custom faces for cells with underline/inverse-video attrs

### DIFF
--- a/vterm-module.c
+++ b/vterm-module.c
@@ -730,6 +730,9 @@ static emacs_value cell_rgb_color(emacs_env *env, Term *term,
                                   VTermScreenCell *cell, bool is_foreground) {
   VTermColor *color = is_foreground ? &cell->fg : &cell->bg;
 
+  /** NOTE: -10 is used as index offset for special indexes,
+   * see C-h f vterm--get-color RET
+   */
   if (VTERM_COLOR_IS_DEFAULT_FG(color)) {
     return vterm_get_color(env, -1 + (cell->attrs.underline ? -10 : 0));
   }

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -82,6 +82,8 @@ typedef struct Term {
   int height_resize;
   bool resizing;
   bool disable_bold_font;
+  bool disable_underline;
+  bool disable_inverse_video;
 
   int pty_fd;
 } Term;
@@ -92,8 +94,8 @@ static emacs_value render_text(emacs_env *env, Term *term, char *string,
                                int len, VTermScreenCell *cell);
 static emacs_value render_fake_newline(emacs_env *env, Term *term);
 static emacs_value render_prompt(emacs_env *env, emacs_value text);
-static emacs_value color_to_rgb_string(emacs_env *env, Term *term,
-                                       VTermColor *color);
+static emacs_value cell_rgb_color(emacs_env *env, Term *term,
+                                  VTermScreenCell *cell, bool is_foreground);
 
 static int term_settermprop(VTermProp prop, VTermValue *val, void *user_data);
 

--- a/vterm.el
+++ b/vterm.el
@@ -145,6 +145,16 @@ party to commandeer your editor."
   :type '(alist :key-type string)
   :group 'vterm)
 
+(defcustom vterm-disable-underline nil
+  "Disable underline for the cells with underline attribute."
+  :type  'boolean
+  :group 'vterm)
+
+(defcustom vterm-disable-inverse-video nil
+  "Disable inverse video for the cells with inverse video attribute."
+  :type  'boolean
+  :group 'vterm)
+
 (defcustom vterm-disable-bold-font nil
   "Disable bold fonts or not."
   :type  'boolean
@@ -213,6 +223,18 @@ The foreground color is used as ansi color 7 and the background
 color is used as ansi color 15."
   :group 'vterm)
 
+(defface vterm-color-underline
+  `((t :inherit vterm-color-default))
+  "Face used to render cells with underline attribute.
+Only foreground is used."
+  :group 'vterm)
+
+(defface vterm-color-inverse-video
+  `((t :inherit vterm-color-default))
+  "Face used to render cells with inverse video attribute.
+Only background is used."
+  :group 'vterm)
+
 (defvar vterm-color-palette
   [vterm-color-black
    vterm-color-red
@@ -258,7 +280,9 @@ If nil, never delay")
                     vterm-min-window-width)))
     (setq vterm--term (vterm--new (window-body-height)
                                   width vterm-max-scrollback
-                                  vterm-disable-bold-font))
+                                  vterm-disable-bold-font
+                                  vterm-disable-underline
+                                  vterm-disable-inverse-video))
     (setq buffer-read-only t)
     (setq-local scroll-conservatively 101)
     (setq-local scroll-margin 0)
@@ -820,6 +844,10 @@ Argument INDEX index of color."
      nil 'default))
    ((= index -1)               ;-1 foreground
     (face-foreground 'vterm-color-default nil 'default))
+   ((= index -11)
+    (face-foreground 'vterm-color-underline nil 'default))
+   ((= index -12)
+    (face-background 'vterm-color-inverse-video nil 'default))
    (t                                   ;-2 background
     (face-background 'vterm-color-default nil 'default))))
 

--- a/vterm.el
+++ b/vterm.el
@@ -832,7 +832,14 @@ If N is negative backward-line from end of buffer."
 
 (defun vterm--get-color(index)
   "Get color by index from `vterm-color-palette'.
-Argument INDEX index of color."
+Argument INDEX index of the terminal color.
+Special values for INDEX are:
+-1 means default foreground.
+-2 for default background.
+-11 foreground for cells with underline attribute, foreground of
+the `vterm-color-underline' face is used in this case.
+-12 background for cells with inverse-video attribute, background
+of the `vterm-color-inverse-video' face is used in this case."
   (cond
    ((and (>= index 0)(< index 8))
     (face-foreground


### PR DESCRIPTION
- `vterm-disable-underline` to resemble xterm's "XTerm\*underLine: off"
- `vterm-color-underline` to resemble xterm's "XTerm\*colorULMode",
  "XTerm\*colorUL"

- `vterm-disable-inverse-video` to disable `:inverse-video`
- `vterm-color-inverse-video` to resemble xterm's "XTerm\*highlightColor"