### PR TITLE
Remove, vterm-title-functions, add vterm-buffer-name-string

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,15 @@ capable, fast, and it can seamlessly handle large outputs.
 ## Warning
 
 This package is in active development and, while being stable enough to be used
-as a daily-driver, it is currently in early **alpha** stage. Moreover,
-emacs-libvterm deals directly with some low-level operations, hence, bugs in the
-code can lead to segmentation faults and crashes. If that happens, please
-[report the problem](https://github.com/akermu/emacs-libvterm/issues/new).
+as a daily-driver, it is currently in early **alpha** stage. This means that
+occasionally the public interface will change (for example names of options or
+functions). A list of recent breaking changes is in
+[appendix](#breaking-changes). Moreover, emacs-libvterm deals directly with some
+low-level operations, hence, bugs in the code can lead to segmentation faults
+and crashes. If that happens, please [report the
+problem](https://github.com/akermu/emacs-libvterm/issues/new).
+
+
 
 # Installation
 
@@ -264,9 +269,40 @@ Controls whether or not to exclude the prompt when copying a line in
 `vterm-copy-mode-done` will invert the value for that call, allowing you to
 temporarily override the setting.
 
-The variable `vterm-copy-use-vterm-prompt` determines
-whether to use the vterm prompt tracking, if false it usessearches for the regexp in
-`vterm-copy-prompt-regexp`.  If not found it copies the whole line.
+The variable `vterm-copy-use-vterm-prompt` determines whether to use the vterm
+prompt tracking, if false it use the regexp in `vterm-copy-prompt-regexp` to
+search for the prompt. If not found, it copies the whole line.
+
+## `vterm-buffer-name-string`
+
+When `vterm-buffer-name-string` is not nil, vterm renames automatically its own
+buffers with `vterm-buffer-name-string`. This string can contain the character
+`%s`, which is substituted with the _title_ (as defined by the shell, see
+below). A possible value for `vterm-buffer-name-string` is `vterm %s`, according
+to which all the vterm buffers will be named "vterm TITLE".
+
+This requires some shell-side configuration to print the title. For example to
+set the name "HOSTNAME:PWD", use can you the following:
+
+For `zsh`
+```zsh
+autoload -U add-zsh-hook
+add-zsh-hook -Uz chpwd (){ print -Pn "\e]2;%m:%2~\a" }
+```
+For `bash`,
+```bash
+PROMPT_COMMAND='echo -ne "\033]0;\h:\w\007"'
+```
+For `fish`,
+```fish
+function fish_title
+    hostname
+    echo ":"
+    pwd
+end
+```
+See [zsh and bash](http://tldp.org/HOWTO/Xterm-Title-4.html) and (fish
+documentations)[https://fishshell.com/docs/current/#programmable-title].
 
 ## Keybindings
 
@@ -510,3 +546,6 @@ open_file_below ~/Documents
 ### Breaking changes
 
 * `vterm-clear-scrollback` was renamed to `vterm-clear-scrollback-when-clearning`.
+* `vterm-set-title-functions` was removed. In its place, there is a new custom
+  option `vterm-buffer-name-string`. See
+  [vterm-buffer-name-string](vterm-buffer-name-string) for documentation.

--- a/vterm.el
+++ b/vterm.el
@@ -1103,7 +1103,7 @@ More information see `vterm--prompt-tracking-enabled-p' and
           (vterm--get-beginning-of-line))))))
 
 (defun vterm--at-prompt-p ()
-  "Return t if the cursor postion is at shell prompt."
+  "Return t if the cursor position is at shell prompt."
   (= (point) (vterm--get-prompt-point)))
 
 (defun vterm-beginning-of-line ()
@@ -1124,7 +1124,7 @@ Effectively toggle between the two positions."
   (goto-char (vterm--get-end-of-line)))
 
 (defun vterm-reset-cursor-point ()
-  "Make sure the cursor at the right postion."
+  "Make sure the cursor at the right position."
   (interactive)
   (vterm--reset-point vterm--term))
 

--- a/vterm.el
+++ b/vterm.el
@@ -203,21 +203,27 @@ Note that this hook will not work if another package like
   :type 'hook
   :group 'vterm)
 
-(defcustom vterm-set-title-functions nil
-  "Shell set title hook.
+(make-obsolete-variable 'vterm-set-title-functions
+                        "This variable was substituted by `vterm-buffer-name-string'."
+                        "0.0.1")
 
-These functions are called one by one, with one argument.
-`vterm-set-title-functions' should be a symbol, a hook variable.
-The value of HOOK may be nil, a function, or a list of functions.
-For example
-    (defun vterm--rename-buffer-as-title (title)
-    (rename-buffer (format \"vterm %s\" title) t))
-    (add-hook 'vterm-set-title-functions
-              'vterm--rename-buffer-as-title)
+(defcustom vterm-buffer-name-string nil
+  "Format string for the title of vterm buffers.
 
-See http://tldp.org/HOWTO/Xterm-Title-4.html about how to set
-terminal title for different shells."
-  :type 'hook
+If `vterm-buffer-name-string' is nil, vterm will not set the
+title of its buffers.  If not nil, `vterm-buffer-name-string' has
+to be a format control string (see `format') containing one
+instance of %s which will be substituted with the string TITLE.
+The argument TITLE is provided by the shell.  This requires shell
+side configuration.
+
+For example, if `vterm-buffer-name-string' is set to \"vterm %s\",
+and the shell properly configured to set TITLE=$(pwd), than vterm
+buffers will be named \"vterm\" followed by the current path.
+
+See URL http://tldp.org/HOWTO/Xterm-Title-4.html for additional
+information on the how to configure the shell."
+  :type 'string
   :group 'vterm)
 
 (defcustom vterm-term-environment-variable "xterm-256color"
@@ -938,8 +944,9 @@ If N is negative backward-line from end of buffer."
     (eq 0 (forward-line n)))))
 
 (defun vterm--set-title (title)
-  "Run the `vterm--set-title-hook' with TITLE as argument."
-  (run-hook-with-args 'vterm-set-title-functions title))
+  "Use TITLE to set the buffer name according to `vterm-buffer-name-string'."
+  (when vterm-buffer-name-string
+    (rename-buffer (format vterm-buffer-name-string title) t)))
 
 (defun vterm--set-directory (path)
   "Set `default-directory' to PATH."


### PR DESCRIPTION
`vterm-title-functions` main purpose is to rename vterm buffers. But, at the moment, it is overly complicated. This PR substitutes `vterm-title-functions` with a new simpler interface that automatically renames buffers with a format string defined by the user. Now, users can simply set `vterm-buffer-name-string` to `%s` to have buffers named after the title (if properly configured shell-side).

If I am missing some use of `vterm-title-functions`, please let me know.