### PR TITLE
Rename vterm-clear-scrollback to vterm-clear-scrollback-when-clearing

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,12 @@ fi
 These aliases take advantage of the fact that `vterm` can execute `elisp`
 commands, as explained below.
 
+If it possible to automatically clear the scrollback when the screen is cleared
+by setting the variable `vterm-clear-scrollback-when-clearing`: When
+`vterm-clear-scrollback-when-clearing` is non nil, `C-l` clears both the screen
+and the scrollback. When is nil, `C-l` only clears the screen. The opposite
+behavior can be achieved by using the universal prefix (ie, calling `C-u C-l`).
+
 # Customization
 
 ## `vterm-shell`
@@ -498,3 +504,9 @@ open_file_below ~/Documents
 
 - [vterm-toggle](https://github.com/jixiuf/vterm-toggle): Toggles between a vterm and the current buffer
 - [multi-libvterm](https://github.com/suonlight/multi-libvterm): Multiterm for emacs-libvterm
+
+## Appendix
+
+### Breaking changes
+
+* `vterm-clear-scrollback` was renamed to `vterm-clear-scrollback-when-clearning`.

--- a/vterm.el
+++ b/vterm.el
@@ -155,14 +155,18 @@ When nil, the buffer will still be available as if it were in
   :type  'boolean
   :group 'vterm)
 
-(defcustom vterm-clear-scrollback nil
-  "Should `vterm-clear' clear the scrollback too?.
+(define-obsolete-variable-alias 'vterm-clear-scrollback
+  'vterm-clear-scrollback-when-clearing "0.0.1")
 
-When nil, `vterm-clear' clears both screen and scrollback,
-otherwise it clears only the screen.
+(defcustom vterm-clear-scrollback-when-clearing nil
+  "If not nil `vterm-clear' clears both screen and scrollback.
 
-Calling `vterm-clear' with a prefix argument does the opposite
-than the default behavior."
+The scrollback is everything that is not current visible on
+screen in vterm buffers.
+
+If `vterm-clear-scrollback-when-clearing' is nil, `vterm-clear'
+clears only the screen, so the scrollback is accessible moving
+the point up."
   :type 'number
   :group 'vterm)
 
@@ -725,8 +729,8 @@ This behavior can be altered by calling `vterm-clear' with a
 prefix argument ARG or with \\[universal-argument]."
   (interactive "P")
   (if (or
-       (and vterm-clear-scrollback (not arg))
-       (and arg (not vterm-clear-scrollback)))
+       (and vterm-clear-scrollback-when-clearing (not arg))
+       (and arg (not vterm-clear-scrollback-when-clearing)))
       (vterm-clear-scrollback))
   (vterm-send-C-l))
 


### PR DESCRIPTION
The option `vterm-clear-scrollback` has a non-descriptive name that clashed with a function named in the same way.