### PR TITLE
Don't resolve symlinks during build

### DIFF
--- a/vterm-module-make.el
+++ b/vterm-module-make.el
@@ -36,7 +36,7 @@ the executable."
   (when (vterm-module--cmake-is-available)
     (let* ((vterm-directory
             (shell-quote-argument
-             (file-name-directory (file-truename (locate-library "vterm")))))
+             (file-name-directory (locate-library "vterm"))))
            (make-commands
             (concat
              "cd " vterm-directory "; \


### PR DESCRIPTION
Hello, I am the maintainer of the package manager straight.el. I received [this bug report](https://github.com/raxod502/straight.el/issues/504) that vterm cannot be used via straight.el. I believe this pull request should fix the issue, while not breaking usage of vterm with package.el. Explanation:

Under package.el, the package files are not symlinks. However, under straight.el, the package files are originally in the Git repository but they are symlinked into a build directory, which is then added to the load-path. Calling file-truename on the vterm library during the native module compilation causes the native module to be put into the Git repository rather than the build directory, meaning it cannot be found by Emacs.