### PR TITLE
Automatic detection for system libvterm first

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,9 @@ if (USE_SYSTEM_LIBVTERM)
 
   # vterm.h is found.
   if (LIBVTERM_INCLUDE_DIR)
-    message(STATUS "System libvterm detected.")
+    message(STATUS "System libvterm detected")
   else()
-    message(STATUS "System libvterm not found. libvterm will be downloaded and compiled as part of the build process.")
+    message(STATUS "System libvterm not found: libvterm will be downloaded and compiled as part of the build process")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,17 +24,24 @@ if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 
 # Look for the header file.
-option(USE_SYSTEM_LIBVTERM "Use system libvterm instead of the vendored version." OFF)
+option(USE_SYSTEM_LIBVTERM "Use system libvterm instead of the vendored version." ON)
 
-if(USE_SYSTEM_LIBVTERM)
-  find_path(LIBVTERM_INCLUDE_DIR NAMES
-    vterm.h
+# Try to find the libvterm in system.
+if (USE_SYSTEM_LIBVTERM)
+  # try to find the vterm.h header file.
+  find_path(LIBVTERM_INCLUDE_DIR
+    NAMES vterm.h
     )
 
-  if(NOT LIBVTERM_INCLUDE_DIR)
-    message(FATAL_ERROR "vterm.h not found")
+  # vterm.h is found.
+  if (LIBVTERM_INCLUDE_DIR)
+    message(STATUS "System libvterm detected.")
+  else()
+    message(STATUS "System libvterm not found. libvterm will be downloaded and compiled as part of the build process.")
   endif()
+endif()
 
+if (LIBVTERM_INCLUDE_DIR)
   find_library(LIBVTERM_LIBRARY NAMES
     vterm
     libvterm

--- a/README.md
+++ b/README.md
@@ -64,12 +64,12 @@ Clone the repository:
 git clone https://github.com/akermu/emacs-libvterm.git
 ```
 
-In case you want to use the version of libvterm already installed on your
-system, change `cmake ..` with `cmake -DUSE_SYSTEM_LIBVTERM=yes ..` in the
-following instructions. If `-DUSE_SYSTEM_LIBVTERM` is not explicitly set to
-`yes` (or if it is set to `no`), emacs-libvterm will download the latest version
-available of libvterm (from [here](https://github.com/neovim/libvterm)), compile
-it, and use it.
+By default, vterm will try to find if libvterm is installed. If it is not found,
+emacs-libvterm will download the latest version available of libvterm (from
+[here](https://github.com/neovim/libvterm)), compile it, and use it. If you
+always want to use the vendored version as opposed to the one on you system, set
+`USE_SYSTEM_LIBVTERM` to `Off`. To do this, change `cmake ..` with `cmake
+-DUSE_SYSTEM_LIBVTERM=Off ..` in the following instructions.
 
 Build the module with:
 


### PR DESCRIPTION
It is mainly for `vterm-module-cmake-args` when it is just installed, it is not available. So I want to use this variable to let `vterm` use the system `libvterm` package. This is done through `CMakeLists.txt`.