### PR TITLE
First build of continuous integration for emacs-libvterm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,53 @@
+# emacs-libvterm CI
+
+name: vterm-continuous-integration
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the vterm-ci branch.
+on:
+  push:
+    branches: [ vterm-ci ]
+  pull_request:
+    branches: [ vterm-ci ]
+
+jobs:
+  ## Build for ubuntu and macos
+  build:
+    strategy:
+      matrix:
+        # The types of runner that the job will run on
+        os: [ ubuntu-latest, macos-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out the repository under $GITHUB_WORKSPACE
+      - uses: actions/checkout@v2
+
+      # Only install for ubuntu
+      - name: Installing dependencies
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          PACKAGES: libtool-bin
+        run: sudo apt install ${PACKAGES}
+
+      # Create the build dir
+      - name: Building make env
+        run: |
+          mkdir Build
+          git config --global advice.detachedHead false
+
+      # Runs cmake
+      - name: Running cmake
+        run: |
+          cd Build
+          cmake ..
+          cd ..
+
+      # Runs make
+      - name: Running make
+        run: |
+          cd Build
+          make
+          cd ..

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         # The types of runner that the job will run on
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, ubuntu-16.04, macos-latest ]
 
     runs-on: ${{ matrix.os }}
 
@@ -27,7 +27,7 @@ jobs:
 
       # Only install for ubuntu
       - name: Installing dependencies
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-16.04' }}
         env:
           PACKAGES: libtool-bin
         run: sudo apt install ${PACKAGES}


### PR DESCRIPTION
This builds on `ubuntu-latest` and `macos-latest`.

Using github actions this:
- retrieves the source
- installs any dependencies (libtool for ubuntu)
- Runs the install as described in README.md
  - makes the Build directory
  - enters it and runs `cmake ..`, returns to home
  - enters it and runs `make`, returns to home

When tests are added we can added `make test` step as well.

I left it as only running on the vterm-ci branch until it's decided how this will fit into the workflow (e.g. does it run on a testing branch or master or both?)

Building on `windows-latest` looks like it should be possible, the image includes cmake support, but I haven't used windows in ages and couldn't figure out how to install libtool.  Someone with more recent experience might have better luck.