### PR TITLE
Ask users for permission to compile module

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,13 @@ The variable `vterm-copy-use-vterm-prompt` determines
 whether to use the vterm prompt tracking, if false it usessearches for the regexp in
 `vterm-copy-prompt-regexp`.  If not found it copies the whole line.
 
+## `vterm-always-compile-module`
+
+Vterm needs `vterm-module` to work. This can be compiled externally, or `vterm`
+will ask the user whether to build the module when `vterm` is first called. To
+avoid this question and always compile the module, set
+`vterm-always-compile-module` to `t`.
+
 ## Keybindings
 
 If you want a key to be sent to the terminal, bind it to `vterm--self-insert`,

--- a/vterm.el
+++ b/vterm.el
@@ -63,6 +63,14 @@ is `-DUSE_SYSTEM_LIBVTERM=yes'."
   :type 'string
   :group 'vterm)
 
+(defcustom vterm-always-compile-module nil
+  "If not nil, if `vterm-module' is not found, compile it without asking.
+
+When `vterm-always-compile-module' is nil, vterm will ask for
+confirmation before compiling."
+  :type  'boolean
+  :group 'vterm)
+
 (defvar vterm-install-buffer-name " *Install vterm* "
   "Name of the buffer used for compiling vterm-module.")
 
@@ -101,8 +109,12 @@ the executable."
 
 ;; If the vterm-module is not compiled yet, compile it
 (unless (require 'vterm-module nil t)
-  (vterm-module-compile)
-  (require 'vterm-module))
+  (if (or vterm-always-compile-module
+            (y-or-n-p "Vterm needs `vterm-module' to work.  Compile it now? "))
+      (progn
+        (vterm-module-compile)
+        (require 'vterm-module))
+    (error "Vterm will not work until `vterm-module' is compiled!")))
 
 ;; Silence compiler warnings by informing it of what functions are defined
 (declare-function display-line-numbers-update-width "display-line-numbers")


### PR DESCRIPTION
`vterm` should ask users the permission to compile the module, instead of doing it without any warning. To avoid asking every time the question, the variable `vterm-always-compile-module` compiles the module without asking (that would be the current behavior).