### PR TITLE
Add shell configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,15 @@ if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
     }
 fi
 ```
+For `fish`:
+```
+if [ "$INSIDE_EMACS" = 'vterm' ]
+    function clear
+        vterm_printf "51;Evterm-clear-scrollback";
+        tput clear;
+    end
+end
+```
 These aliases take advantage of the fact that `vterm` can execute `elisp`
 commands, as explained below.
 
@@ -548,6 +557,14 @@ Then you can open any file from inside your shell.
 ```sh
 open_file_below ~/Documents
 ```
+
+## Shell-side configuration files
+
+The configurations described in earlier sections are combined in
+[`etc/`](./etc/). These can be appended to or loaded into your user
+configuration file. Alternatively, they can be installed system-wide, for
+example in `/etc/bash/bashrc.d/`, `/etc/profile.d/` (for `zsh`), or
+`/etc/fish/conf.d/` for `fish`.
 
 ## Frequently Asked Questions and Problems
 

--- a/etc/emacs-vterm-bash.sh
+++ b/etc/emacs-vterm-bash.sh
@@ -1,0 +1,42 @@
+# Some of the most useful features in emacs-libvterm require shell-side
+# configurations. The main goal of these additional functions is to enable the
+# shell to send information to `vterm` via properly escaped sequences. A
+# function that helps in this task, `vterm_printf`, is defined below.
+
+function vterm_printf(){
+    if [ -n "$TMUX" ]; then
+        # Tell tmux to pass the escape sequences through
+        # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+        printf "\ePtmux;\e\e]%s\007\e\\" "$1"
+    elif [ "${TERM%%-*}" = "screen" ]; then
+        # GNU screen (screen, screen-256color, screen-256color-bce)
+        printf "\eP\e]%s\007\e\\" "$1"
+    else
+        printf "\e]%s\e\\" "$1"
+    fi
+}
+
+# Completely clear the buffer. With this, everything that is not on screen
+# is erased.
+if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
+    function clear(){
+        vterm_printf "51;Evterm-clear-scrollback";
+        tput clear;
+    }
+fi
+
+# This is to change the title of the buffer based on information provided by the
+# shell. See, http://tldp.org/HOWTO/Xterm-Title-4.html, for the meaning of the
+# various symbols.
+PROMPT_COMMAND='echo -ne "\033]0;\h:\w\007"'
+
+# Sync directory and host in the shell with Emacs's current directory.
+# You may need to manually specify the hostname instead of $(hostname) in case
+# $(hostname) does not return the correct string to connect to the server.
+#
+# The escape sequence "51;A" has also the role of identifying the end of the
+# prompt
+vterm_prompt_end(){
+    vterm_printf "51;A$(whoami)@$(hostname):$(pwd)"
+}
+PS1=$PS1'\[$(vterm_prompt_end)\]'

--- a/etc/emacs-vterm-zsh.sh
+++ b/etc/emacs-vterm-zsh.sh
@@ -1,0 +1,41 @@
+# Some of the most useful features in emacs-libvterm require shell-side
+# configurations. The main goal of these additional functions is to enable the
+# shell to send information to `vterm` via properly escaped sequences. A
+# function that helps in this task, `vterm_printf`, is defined below.
+
+function vterm_printf(){
+    if [ -n "$TMUX" ]; then
+        # Tell tmux to pass the escape sequences through
+        # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+        printf "\ePtmux;\e\e]%s\007\e\\" "$1"
+    elif [ "${TERM%%-*}" = "screen" ]; then
+        # GNU screen (screen, screen-256color, screen-256color-bce)
+        printf "\eP\e]%s\007\e\\" "$1"
+    else
+        printf "\e]%s\e\\" "$1"
+    fi
+}
+
+# Completely clear the buffer. With this, everything that is not on screen
+# is erased.
+if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
+    alias clear='vterm_printf "51;Evterm-clear-scrollback";tput clear'
+fi
+
+# This is to change the title of the buffer based on information provided by the
+# shell. See, http://tldp.org/HOWTO/Xterm-Title-4.html, for the meaning of the
+# various symbols.
+autoload -U add-zsh-hook
+add-zsh-hook -Uz chpwd (){ print -Pn "\e]2;%m:%2~\a" }
+
+# Sync directory and host in the shell with Emacs's current directory.
+# You may need to manually specify the hostname instead of $(hostname) in case
+# $(hostname) does not return the correct string to connect to the server.
+#
+# The escape sequence "51;A" has also the role of identifying the end of the
+# prompt
+vterm_prompt_end() {
+    vterm_printf "51;A$(whoami)@$(hostname):$(pwd)";
+}
+setopt PROMPT_SUBST
+PROMPT=$PROMPT'%{$(vterm_prompt_end)%}'

--- a/etc/emacs-vterm.fish
+++ b/etc/emacs-vterm.fish
@@ -1,0 +1,54 @@
+# Some of the most useful features in emacs-libvterm require shell-side
+# configurations. The main goal of these additional functions is to enable the
+# shell to send information to `vterm` via properly escaped sequences. A
+# function that helps in this task, `vterm_printf`, is defined below.
+
+function vterm_printf;
+    if [ -n "$TMUX" ]
+        # tell tmux to pass the escape sequences through
+        # (Source: http://permalink.gmane.org/gmane.comp.terminal-emulators.tmux.user/1324)
+        printf "\ePtmux;\e\e]%s\007\e\\" "$argv"
+    else if string match -q -- "screen*" "$TERM"
+        # GNU screen (screen, screen-256color, screen-256color-bce)
+        printf "\eP\e]%s\007\e\\" "$argv"
+    else
+        printf "\e]%s\e\\" "$argv"
+    end
+end
+
+# Completely clear the buffer. With this, everything that is not on screen
+# is erased.
+if [ "$INSIDE_EMACS" = 'vterm' ]
+    function clear
+        vterm_printf "51;Evterm-clear-scrollback";
+        tput clear;
+    end
+end
+
+# This is to change the title of the buffer based on information provided by the
+# shell. See, http://tldp.org/HOWTO/Xterm-Title-4.html, for the meaning of the
+# various symbols.
+function fish_title
+    hostname
+    echo ":"
+    pwd
+end
+
+# Sync directory and host in the shell with Emacs's current directory.
+# You may need to manually specify the hostname instead of $(hostname) in case
+# $(hostname) does not return the correct string to connect to the server.
+#
+# The escape sequence "51;A" has also the role of identifying the end of the
+# prompt
+function vterm_prompt_end;
+    vterm_printf '51;A'(whoami)'@'(hostname)':'(pwd)
+end
+functions -c fish_prompt vterm_old_fish_prompt
+
+function fish_prompt --description 'Write out the prompt; do not replace this. Instead, put this at end of your file.'
+    # Remove the trailing newline from the original prompt. This is done
+    # using the string builtin from fish, but to make sure any escape codes
+    # are correctly interpreted, use %b for printf.
+    printf "%b" (string join "\n" (vterm_old_fish_prompt))
+    vterm_prompt_end
+end


### PR DESCRIPTION
Combining the described configurations into separate files makes it easier for users to configure their shell. Also, package managers could automatically install them system-wide, see for example [a Gentoo ebuild](https://github.com/gentoo/guru/blob/master/app-emacs/vterm/vterm-20200504.544.ebuild).