### PR TITLE
Update documentation and docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,16 @@ open_file_below ~/Documents
 
 ## Frequently Asked Questions and Problems
 
+### How can I increase the size of the scrollback?
+
+By default, the scrollback can contain up to 1000 lines per each vterm buffer.
+You can increase this up to 100000 by changing the variable
+`vterm-max-scrollback`. If you want to increase it further, you have to edit the
+file `vterm-module.h`, change the variable `SB_MAX`, and set the new value for
+`vterm-max-scrollback`. The potential maximum memory consumption of vterm
+buffers increases with `vterm-max-scrollback`, so setting `SB_MAX` to extreme
+values may lead to system instabilities and crashes.
+ 
 ### How can I automatically close vterm buffers when the process is terminated?
 
 There is an option for that: set `vterm-kill-buffer-on-exit` to `t`.

--- a/README.md
+++ b/README.md
@@ -38,15 +38,16 @@ For the long answer, let us discuss the differences between `eshell`, `shell`,
   directly manipulate the output using escape codes. Hence, many interactive
   applications (like the one aforementioned) work with `term`. However, `term`
   and `ansi-term` do not implement all the escapes codes needed, so some
-  programs do not work properly. Moreover, `term` has performance inferior
+  programs do not work properly. Moreover, `term` has inferior performance
   compared to standalone terminals, especially with large bursts of output.
 - `vterm`: like `term` it is a terminal emulator. Unlike `term`, the core of
   `vterm` is an external library written in C, `libvterm`. For this reason,
   `vterm` outperforms `term` and has a nearly universal compatibility with
   terminal applications.
 
-Therefore, vterm is not for you if you are using Windows, or if you cannot set
-up Emacs with support for modules.
+Vterm is not for you if you are using Windows, or if you cannot set up Emacs
+with support for modules. Otherwise, you should try vterm, as it provides a
+superior terminal experience in Emacs.
 
 Using `vterm` is like using Gnome Terminal inside Emacs: Vterm is fully-featured
 and fast, but is not as well integrated in Emacs as `eshell` (yet), so some of

--- a/README.md
+++ b/README.md
@@ -258,8 +258,9 @@ rendering of colors in some systems.
 
 ## `vterm-kill-buffer-on-exit`
 
-If set to `t`, buffers are killed when the associated process is terminated
-(for example, by logging out the shell).
+If set to `t`, buffers are killed when the associated process is terminated (for
+example, by logging out the shell). Keeping buffers around it is useful if you
+need to copy or manipulate the content.
 
 ## `vterm-module-cmake-args`
 

--- a/vterm.el
+++ b/vterm.el
@@ -300,12 +300,24 @@ rendered as normal ones."
   :group 'vterm)
 
 (defcustom vterm-copy-exclude-prompt t
-  "When not nil the prompt is not included by `vterm-copy-mode-done'."
+  "When not-nil, the prompt is not included by `vterm-copy-mode-done'."
   :type 'boolean
   :group 'vterm)
 
 (defcustom vterm-use-vterm-prompt-detection-method t
-  "Should we use the vterm prompt tracker or the search from `term-prompt-regexp'?"
+  "When not-nil, the prompt is detected through the shell.
+
+Vterm needs to know where the shell prompt is to enable all the
+available features.  There are two supported ways to do this.
+First, the shell can inform vterm on the location of the prompt.
+This requires shell-side configuration: the escape code 51;A is
+used to set the current directory and prompt location.  This
+detection method is the most-reliable.  To use it, you have
+to change your shell prompt to print 51;A.
+
+The second method is using a regular expression. This method does
+not require any shell-side configuration. See
+`term-prompt-regexp', for more information."
   :type 'boolean
   :group 'vterm)
 

--- a/vterm.el
+++ b/vterm.el
@@ -1,4 +1,4 @@
-;;; vterm.el --- This package implements a terminal via libvterm -*- lexical-binding: t; -*-
+;;; vterm.el --- Fully-featured terminal emulator -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2017-2020 by Lukas Fürmetz & Contributors
 ;;


### PR DESCRIPTION
1. Change the default value of `vterm-kill-buffer-on-exit` to t. 
2. Add comparison between vterm and other terms and shells. Fixes #14. 
3. Change `vterm-use-vterm-prompt` to `vterm-use-vterm-prompt-detection-method`. Addresses #306.
4. Update package description and commentary
5. Expand other documentation