### PR TITLE
With the native-compile feature enabled, properly find build dir

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -104,7 +104,7 @@ the executable."
   (when (vterm-module--cmake-is-available)
     (let* ((vterm-directory
             (shell-quote-argument
-             (file-name-directory (locate-library "vterm"))))
+             (file-name-directory (find-library-name "vterm"))))
            (make-commands
             (concat
              "cd " vterm-directory "; \

--- a/vterm.el
+++ b/vterm.el
@@ -104,6 +104,11 @@ the executable."
   (when (vterm-module--cmake-is-available)
     (let* ((vterm-directory
             (shell-quote-argument
+             ;; NOTE: This is a workaround to fix an issue with how the Emacs
+             ;; feature/native-comp branch changes the result of
+             ;; `(locate-library "vterm")'. See emacs-devel thread
+             ;; https://lists.gnu.org/archive/html/emacs-devel/2020-07/msg00306.html
+             ;; for a discussion.
              (file-name-directory (locate-library "vterm.el" t))))
            (make-commands
             (concat

--- a/vterm.el
+++ b/vterm.el
@@ -97,7 +97,6 @@ the executable."
     (error "Vterm needs CMake to be compiled.  Please, install CMake"))
   t)
 
-(autoload 'find-library-name "find-func")
 ;;;###autoload
 (defun vterm-module-compile ()
   "Compile vterm-module."
@@ -105,7 +104,7 @@ the executable."
   (when (vterm-module--cmake-is-available)
     (let* ((vterm-directory
             (shell-quote-argument
-             (file-name-directory (find-library-name "vterm"))))
+             (file-name-directory (locate-library "vterm.el" t))))
            (make-commands
             (concat
              "cd " vterm-directory "; \

--- a/vterm.el
+++ b/vterm.el
@@ -97,7 +97,7 @@ the executable."
     (error "Vterm needs CMake to be compiled.  Please, install CMake"))
   t)
 
-(declare-function find-library-name "find-func")
+(autoload 'find-library-name "find-func")
 ;;;###autoload
 (defun vterm-module-compile ()
   "Compile vterm-module."

--- a/vterm.el
+++ b/vterm.el
@@ -97,6 +97,7 @@ the executable."
     (error "Vterm needs CMake to be compiled.  Please, install CMake"))
   t)
 
+(declare-function find-library-name "find-func")
 ;;;###autoload
 (defun vterm-module-compile ()
   "Compile vterm-module."


### PR DESCRIPTION
When the native-compile feature is enabled, `locate-library` returns the path to
the compiled (`.eln`) file rather than the `.el` or `.elc` that would otherwise
be expected. Then `vterm-module-compile` runs the compilation from that
subdirectory and can't find the expected files.

`find-library-name` always returns the `.el` file location.

Example error:
```
CMake Error: The source directory "/Users/user/.emacs.d/straight/build/vterm/eln-x86_64-apple-darwin19.5.0-89a730c11dec204e" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
make: *** No targets specified and no makefile found.  Stop.
```

After this change the compilation files are found as expected.