### PR TITLE
Fix unsettable vterm-keymap-exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,6 +296,16 @@ behavior can be achieved by using the universal prefix (ie, calling `C-u C-l`).
 
 Shell to run in a new vterm. It defaults to `$SHELL`.
 
+## `vterm-keymap-exceptions`
+
+All the keybindings `C-*`, `M-*` are sent to vterm (where `*` is any character),
+except those defined in the list `vterm-keymap-exceptions`. Some of the ones
+excluded by default are `C-x` or `M-x`, which are captured by Emacs instead.
+
+If you customize this variable, the change will be applied to all the new
+`vterm` sessions, so you may need to restart the ones that are currently
+running.
+
 ## `vterm-term-environment-variable`
 
 Value for the `TERM` environment variable. It defaults to `xterm-256color`. If
@@ -375,7 +385,8 @@ If you want a key to be sent to the terminal, bind it to `vterm--self-insert`,
 or remove it from `vterm-mode-map`. By default, `vterm.el` binds most of the
 `C-<char>` and `M-<char>` keys, `<f1>` through `<f12>` and some special keys
 like `<backspace>` and `<return>`. Sending a keyboard interrupt is bound to `C-c
-C-c`.
+C-c`.  You can customize the default keybindings to ignore by customizing
+`vterm-keymap-exceptions`.
 
 ## Fonts
 

--- a/README.md
+++ b/README.md
@@ -298,13 +298,18 @@ Shell to run in a new vterm. It defaults to `$SHELL`.
 
 ## `vterm-keymap-exceptions`
 
-All the keybindings `C-*`, `M-*` are sent to vterm (where `*` is any character),
-except those defined in the list `vterm-keymap-exceptions`. Some of the ones
-excluded by default are `C-x` or `M-x`, which are captured by Emacs instead.
+All the key bindings `C-*`, `M-*` are sent to vterm (where `*` is any
+character), except those defined in the list `vterm-keymap-exceptions`. Some of
+the ones excluded by default are `C-x` or `M-x`, which are captured by Emacs
+instead.
 
 If you customize this variable, the change will be applied to all the new
 `vterm` sessions, so you may need to restart the ones that are currently
 running.
+
+Please note that if you bind keys to `vterm-mode-map` before a `vterm` session
+is launched, your key bindings overrides the same bindings in
+`vterm-keymap-exceptions`.
 
 ## `vterm-term-environment-variable`
 
@@ -381,12 +386,12 @@ avoid this question and always compile the module, set
 
 ## Keybindings
 
-If you want a key to be sent to the terminal, bind it to `vterm--self-insert`,
-or remove it from `vterm-mode-map`. By default, `vterm.el` binds most of the
-`C-<char>` and `M-<char>` keys, `<f1>` through `<f12>` and some special keys
-like `<backspace>` and `<return>`. Sending a keyboard interrupt is bound to `C-c
-C-c`.  You can customize the default keybindings to ignore by customizing
-`vterm-keymap-exceptions`.
+If you want a key to be sent to the terminal, bind it to `vterm--self-insert`, ,
+remove it from or rebind it in `vterm-mode-map`. By default, `vterm.el` binds
+most of the `C-<char>` and `M-<char>` keys, `<f1>` through `<f12>` and some
+special keys like `<backspace>` and `<return>`. Sending a keyboard interrupt is
+bound to `C-c C-c`.  You can customize the default keybindings to ignore by
+customizing `vterm-keymap-exceptions`.
 
 ## Fonts
 

--- a/vterm.el
+++ b/vterm.el
@@ -216,7 +216,11 @@ If you use a keybinding with a prefix-key, add that prefix-key to
 this list.  Note that after doing so that prefix-key cannot be
 sent to the terminal anymore, and if you have a running vterm
 session, you will need to restart `vterm-mode' in the terminal
-buffer in order to have the exceptions to take effect."
+buffer in order to have the exceptions to take effect.
+
+Please note that if a keybinding exists in `vterm-mode-map'
+before a vterm session is launched, adding that binding to this
+variable has no effect."
   :type '(repeat string)
   :group 'vterm)
 

--- a/vterm.el
+++ b/vterm.el
@@ -558,8 +558,9 @@ Bind keys to MAP except for those in EXCEPTIONS."
 (define-derived-mode vterm-mode fundamental-mode "VTerm"
   "Major mode for vterm buffer."
 
-  ;; Remove keys in vterm-keymap-exceptions from vterm-mode-map
+  ;; Remove keys in vterm-keymap-exceptions from vterm-mode-map unless bound
   (cl-loop for exception in vterm-keymap-exceptions
+           if (null (lookup-key vterm-mode-map exception))
            do (define-key vterm-mode-map (kbd exception) nil))
 
   (buffer-disable-undo)


### PR DESCRIPTION
`vterm-keymap-exceptions` is unsettable due to the `:set` function is calling `vterm--exclude-keys` with a wrong number of arguments, and that it is using `set` instead of `set-default` so the values cannot be persisted. This PR fixes this issue, simplifies the implementation and did some code clean up.