### PR TITLE
Correctly place cursor after EOL

### DIFF
--- a/vterm-module.c
+++ b/vterm-module.c
@@ -233,7 +233,7 @@ static int is_end_of_prompt(Term *term, int end_col, int row, int col) {
   return 0;
 }
 
-static void goto_col(Term *term, emacs_env *env, int row, int end_col) {
+static void goto_col(Term *term, emacs_env *env, int row, int end_col, bool fill_eol_spaces) {
   int col = 0;
   size_t offset = 0;
   size_t beyond_eol = 0;
@@ -259,9 +259,11 @@ static void goto_col(Term *term, emacs_env *env, int row, int end_col) {
   }
 
   forward_char(env, env->make_integer(env, end_col - offset));
-  emacs_value space = env->make_string(env, " ", 1);
-  for (int i = 0 ; i < beyond_eol ; i += 1)
-    insert(env, space);
+  if (fill_eol_spaces) {
+    emacs_value space = env->make_string(env, " ", 1);
+    for (int i = 0 ; i < beyond_eol ; i += 1)
+      insert(env, space);
+  }
 }
 
 static void refresh_lines(Term *term, emacs_env *env, int start_row,
@@ -473,7 +475,7 @@ static void adjust_topline(Term *term, emacs_env *env) {
    */
 
   goto_line(env, pos.row - term->height);
-  goto_col(term, env, pos.row, pos.col);
+  goto_col(term, env, pos.row, pos.col, true);
 
   emacs_value windows = get_buffer_window_list(env);
   emacs_value swindow = selected_window(env);
@@ -1348,7 +1350,7 @@ emacs_value Fvterm_reset_cursor_point(emacs_env *env, ptrdiff_t nargs,
   Term *term = env->get_user_ptr(env, args[0]);
   int line = row_to_linenr(term, term->cursor.row);
   goto_line(env, line);
-  goto_col(term, env, term->cursor.row, term->cursor.col);
+  goto_col(term, env, term->cursor.row, term->cursor.col, false);
   return point(env);
 }
 

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -232,9 +232,11 @@ static int is_end_of_prompt(Term *term, int end_col, int row, int col) {
   }
   return 0;
 }
-static size_t get_col_offset(Term *term, int row, int end_col) {
+
+static void goto_col(Term *term, emacs_env *env, int row, int end_col) {
   int col = 0;
   size_t offset = 0;
+  size_t beyond_eol = 0;
 
   int height;
   int width;
@@ -250,11 +252,16 @@ static size_t get_col_offset(Term *term, int row, int end_col) {
     } else {
       if (is_eol(term, term->width, row, col)) {
         offset += cell.width;
+        beyond_eol += cell.width;
       }
     }
     col += cell.width;
   }
-  return offset;
+
+  forward_char(env, env->make_integer(env, end_col - offset));
+  emacs_value space = env->make_string(env, " ", 1);
+  for (int i = 0 ; i < beyond_eol ; i += 1)
+    insert(env, space);
 }
 
 static void refresh_lines(Term *term, emacs_env *env, int start_row,
@@ -466,8 +473,7 @@ static void adjust_topline(Term *term, emacs_env *env) {
    */
 
   goto_line(env, pos.row - term->height);
-  size_t offset = get_col_offset(term, pos.row, pos.col);
-  forward_char(env, env->make_integer(env, pos.col - offset));
+  goto_col(term, env, pos.row, pos.col);
 
   emacs_value windows = get_buffer_window_list(env);
   emacs_value swindow = selected_window(env);
@@ -1342,8 +1348,7 @@ emacs_value Fvterm_reset_cursor_point(emacs_env *env, ptrdiff_t nargs,
   Term *term = env->get_user_ptr(env, args[0]);
   int line = row_to_linenr(term, term->cursor.row);
   goto_line(env, line);
-  size_t offset = get_col_offset(term, term->cursor.row, term->cursor.col);
-  forward_char(env, env->make_integer(env, term->cursor.col - offset));
+  goto_col(term, env, term->cursor.row, term->cursor.col);
   return point(env);
 }
 


### PR DESCRIPTION
If the cursor position is set beyond the EOL, insert spaces

Fixes https://github.com/akermu/emacs-libvterm/issues/398

---

Some application will want to place the cursor after EOL. E.g., in iPython, after pressing some spaces at the end of the line, the content of current line will be like "[0]:" (without any spaces) but the column of the position of the cursor may be 6 (greater than the length of the content of current line). This PR fixes this bug by inserting additional spaces at end of the line so that the cursor can be correctly placed.

Calls to `get_col_offset` and `forward_char` together is now replaced with one function `goto_col`, which will place the cursor at the target column (like `goto_line`). `goto_col` is pretty the same as `get_col_offset` except that it also calculates how many spaces there is after the EOL. After calling `forward_char` as before, it then inserts spaces if required.