### PR TITLE
Support osc 52 Manipulate Selection Data. #343

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,26 @@ The variable `vterm-use-vterm-prompt-detection-method` determines whether to use
 the vterm prompt tracking, if false it use the regexp in
 `vterm-copy-prompt-regexp` to search for the prompt.
 
+## `vterm-enable-manipulate-selection-data-by-osc52`
+
+Vterm support copy text to emacs kill ring and system clipboard by using OSC 52.
+See https://invisible-island.net/xterm/ctlseqs/ctlseqs.html for more info about OSC 52.
+For example: send 'blabla' to kill ring: printf "\033]52;c;$(printf "%s" "blabla" | base64)\a"
+
+tmux can share its copy buffer to terminals bysupporting osc52(like iterm2 xterm),
+you can enable this feature for tmux by :
+set -g set-clipboard on         #osc 52 copy paste share with iterm
+set -ga terminal-overrides ',xterm*:XT:Ms=\E]52;%p1%s;%p2%s\007'
+set -ga terminal-overrides ',screen*:XT:Ms=\E]52;%p1%s;%p2%s\007'
+
+The clipboard querying/clearing functionality offered by OSC 52 is not implemented here,
+And for security reason, this feature is disabled by default."
+
+This feature need the new way of handling strings with a struct `VTermStringFragment`
+in libvterm. You'd better compile emacs-libvterm with `cmake -DUSE_SYSTEM_LIBVTERM=no ..`.
+If you don't do that, when  the content you want to copied is too long, it would be truncated
+by bug of libvterm.
+
 ## `vterm-buffer-name-string`
 
 When `vterm-buffer-name-string` is not nil, vterm renames automatically its own

--- a/elisp.c
+++ b/elisp.c
@@ -54,6 +54,7 @@ emacs_value Fvterm_invalidate;
 emacs_value Feq;
 emacs_value Fvterm_get_color;
 emacs_value Fvterm_eval;
+emacs_value Fvterm_selection;
 
 /* Set the function cell of the symbol named NAME to SFUN using
    the 'fset' function.  */
@@ -193,4 +194,10 @@ void vterm_invalidate(emacs_env *env) {
 }
 emacs_value vterm_eval(emacs_env *env, emacs_value string) {
   return env->funcall(env, Fvterm_eval, 1, (emacs_value[]){string});
+}
+
+emacs_value vterm_selection(emacs_env *env, emacs_value selection_target,
+                            emacs_value selection_data) {
+  return env->funcall(env, Fvterm_selection, 2,
+                      (emacs_value[]){selection_target, selection_data});
 }

--- a/elisp.h
+++ b/elisp.h
@@ -57,6 +57,7 @@ extern emacs_value Fvterm_invalidate;
 extern emacs_value Feq;
 extern emacs_value Fvterm_get_color;
 extern emacs_value Fvterm_eval;
+extern emacs_value Fvterm_selection;
 
 // Utils
 void bind_function(emacs_env *env, const char *name, emacs_value Sfun);
@@ -90,5 +91,7 @@ void set_directory(emacs_env *env, emacs_value string);
 void vterm_invalidate(emacs_env *env);
 emacs_value vterm_get_color(emacs_env *env, int index);
 emacs_value vterm_eval(emacs_env *env, emacs_value string);
+emacs_value vterm_selection(emacs_env *env, emacs_value selection_target,
+                            emacs_value selection_data);
 
 #endif /* ELISP_H */

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -38,6 +38,10 @@ enum {
   VTERM_PROP_CURSOR_NOT_VISIBLE = 5,
 };
 
+/*  c , p , q , s , 0 , 1 , 2 , 3 , 4 , 5 , 6 , and 7  */
+/* clipboard, primary, secondary, select, or cut buffers 0 through 7 */
+#define SELECTION_TARGET_MAX 12
+
 typedef struct Cursor {
   int row, col;
   int cursor_type;
@@ -74,6 +78,11 @@ typedef struct Term {
 
   char *elisp_code;
   bool elisp_code_changed;
+
+  /*  c , p , q , s , 0 , 1 , 2 , 3 , 4 , 5 , 6 , and 7  */
+  /* clipboard, primary, secondary, select, or cut buffers 0 through 7 */
+  char selection_target[SELECTION_TARGET_MAX];
+  char *selection_data;
 
   /* the size of dirs almost = window height, value = directory of that line */
   LineInfo **lines;


### PR DESCRIPTION
this pull request need merged after #404 

Add option: `vterm-enable-manipulate-selection-data-by-osc52`

Vterm support copy text to emacs kill ring and system clipboard by using OSC 52.
See https://invisible-island.net/xterm/ctlseqs/ctlseqs.html for more info about OSC 52.
For example: send 'blabla' to kill ring(and clipboard): printf "\033]52;c;$(printf "%s" "blabla" | base64)\a"

tmux can share its copy buffer to terminals bysupporting osc52(like iterm2 xterm),
you can enable this feature for tmux by :
set -g set-clipboard on         #osc 52 copy paste share with iterm
set -ga terminal-overrides ',xterm*:XT:Ms=\E]52;%p1%s;%p2%s\007'
set -ga terminal-overrides ',screen*:XT:Ms=\E]52;%p1%s;%p2%s\007'

The clipboard querying/clearing functionality offered by OSC 52 is not implemented here,

And for security reason, this feature is disabled by default."


This feature need the new way of handling strings with a struct `VTermStringFragment`
in libvterm. You'd better compile emacs-libvterm with `cmake -DUSE_SYSTEM_LIBVTERM=no ..`.
If you don't do that, when  the content you want to copied is too long, it would be truncated
by bug of libvterm.
