### PR TITLE
Revert "avoid garbling of certain multibyte characters ."

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -430,7 +430,6 @@ Only background is used."
 (defvar-local vterm--redraw-immididately nil)
 (defvar-local vterm--linenum-remapping nil)
 (defvar-local vterm--prompt-tracking-enabled-p nil)
-(defvar-local vterm--undecoded-bytes nil)
 
 (defvar vterm-timer-delay 0.1
   "Delay for refreshing the buffer after receiving updates from libvterm.
@@ -961,35 +960,10 @@ be set to BUFFER-NAME, otherwise it will be `vterm'"
 Then triggers a redraw from the module."
   (let ((inhibit-redisplay t)
         (inhibit-read-only t)
-        (buf (process-buffer process))
-        (decoded-str))
+        (buf (process-buffer process)))
     (when (buffer-live-p buf)
       (with-current-buffer buf
-        ;; Borrowed from term.el
-        ;;
-        ;; Avoid garbling of certain multibyte characters by decoding the string
-        ;; before counting characters.  See,
-        ;; https://github.com/akermu/emacs-libvterm/issues/394, and the
-        ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=1006 (for term.el).
-        (when vterm--undecoded-bytes
-          (setq input (concat vterm--undecoded-bytes input))
-          (setq vterm--undecoded-bytes nil))
-        (setq decoded-str
-              (decode-coding-string input locale-coding-system t))
-        (let ((partial 0)
-              (count (length decoded-str)))
-          (while (and (< partial count)
-                      (eq (char-charset (aref decoded-str
-                                              (- count 1 partial)))
-                          'eight-bit))
-            (cl-incf partial))
-          (when (> count partial 0)
-            (setq vterm--undecoded-bytes
-                  (substring decoded-str (- partial)))
-            (setq decoded-str
-                  (substring decoded-str 0 (- partial)))))
-
-        (vterm--write-input vterm--term decoded-str)
+        (vterm--write-input vterm--term input)
         (vterm--update vterm--term)))))
 
 (defun vterm--sentinel (process event)


### PR DESCRIPTION
This reverts commit a43f9702007436bc243673164c405e37c77ed1f3.