### PR TITLE
Fix missing map argument when setting vterm-keymap-exceptions

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -223,7 +223,7 @@ function `vterm--exclude-keys' removes the keybindings defined in
   :set (lambda (sym val)
          (set sym val)
          (when (fboundp 'vterm--exclude-keys)
-           (vterm--exclude-keys val)))
+           (vterm--exclude-keys 'vterm-mode-map val)))
   :group 'vterm)
 
 (defcustom vterm-exit-functions nil


### PR DESCRIPTION
https://github.com/akermu/emacs-libvterm/pull/383 introduced an update to `vterm--exclude-keys` with a new map argument.

This PR adds the correct argument for the `set` function when customizing `vterm-keymap-exceptions`.