### PR TITLE
Add Cmake rules for OpenBSD & NetBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ include(ExternalProject)
 
 project(emacs-libvterm C)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
+if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD" OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
    set(LIBVTERM_BUILD_COMMAND "gmake")
 else()
    set(LIBVTERM_BUILD_COMMAND "make")


### PR DESCRIPTION
BSD make barfs on the libvterm Makefile that gets pulled in if you try to build without the system libvterm (i.e. `cmake -DUSE_SYSTEM_LIBVTERM=no ..`) This adds rules for OpenBSD and NetBSD so that they use GNU make.