### PR TITLE
Minimize text properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,7 +459,7 @@ C-c`.
 
 ## Fonts
 
-If you would like to change the font or face used in a vterm, use the following code:
+You can change the font (the _face_) used in a vterm with the following code:
 
 ``` emacs
 (add-hook 'vterm-mode-hook
@@ -468,8 +468,14 @@ If you would like to change the font or face used in a vterm, use the following 
                  (buffer-face-mode t)))
 ```
 
-The above would change change the font in vterm buffers to a mono-spaced font
-(the `fixed-pitch` face) if your default font in Emacs is a proportional font.
+Where instead of `'fixed-pitch` you specify the face you want to use. The
+example reported here can be used to force vterm to use a mono-spaced font (the
+`fixed-pitch` face). This is useful when your default font in Emacs is a
+proportional font.
+
+In addition to that, you can disable some text properties (bold, underline,
+reverse video) setting the relative option to `t` (`vterm-disable-bold`,
+`vterm-disable-underline`, or `vterm-disable-inverse-video`).
 
 ## Colors
 
@@ -825,6 +831,11 @@ not appropriate in some cases like terminals."
 ### Breaking changes
 
 Obsolete variables will be removed in version 0.1.
+
+#### October 2020
+
+* `vterm-disable-bold-font` was renamed to `vterm-disable-bold` to uniform it
+   with the other similar options.
 
 #### July 2020
 

--- a/README.md
+++ b/README.md
@@ -483,7 +483,6 @@ Set the `:foreground` and `:background` attributes of the following faces to a
 color you like. The `:foreground` is ansi color 0-7, the `:background` attribute
 is ansi color 8-15.
 
-- vterm-color-default
 - vterm-color-black
 - vterm-color-red
 - vterm-color-green

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -713,21 +713,25 @@ static emacs_value render_text(emacs_env *env, Term *term, char *buffer,
   int emacs_major_version =
       env->extract_integer(env, symbol_value(env, Qemacs_major_version));
   emacs_value properties;
-  if (emacs_major_version >= 27) {
-    properties =
-        list(env,
-             (emacs_value[]){Qforeground, fg, Qbackground, bg, Qweight, bold,
-                             Qunderline, underline, Qslant, italic, Qreverse,
-                             reverse, Qstrike, strike, Qextend, Qt},
-             16);
-  } else {
-    properties =
-        list(env,
-             (emacs_value[]){Qforeground, fg, Qbackground, bg, Qweight, bold,
-                             Qunderline, underline, Qslant, italic, Qreverse,
-                             reverse, Qstrike, strike},
-             14);
-  }
+  emacs_value props[64]; int props_len = 0;
+  if (env->is_not_nil (env, fg))
+    props[props_len++] = Qforeground, props[props_len++] = fg;
+  if (env->is_not_nil (env, bg))
+    props[props_len++] = Qbackground, props[props_len++] = bg;
+  if (bold != Qnormal)
+    props[props_len++] = Qweight, props[props_len++] = bold;
+  if (underline != Qnil)
+    props[props_len++] = Qunderline, props[props_len++] = underline;
+  if (italic != Qnormal)
+    props[props_len++] = Qslant, props[props_len++] = italic;
+  if (reverse != Qnil)
+    props[props_len++] = Qreverse, props[props_len++] = reverse;
+  if (strike != Qnil)
+    props[props_len++] = Qstrike, props[props_len++] = strike;
+  if (emacs_major_version >= 27)
+    props[props_len++] = Qextend, props[props_len++] = Qt;
+
+  properties = list (env, props, props_len);
 
   put_text_property(env, text, Qface, properties);
 

--- a/vterm.el
+++ b/vterm.el
@@ -317,20 +317,28 @@ The need for an explicit map is to avoid arbitrary code execution."
   :group 'vterm)
 
 (defcustom vterm-disable-underline nil
-  "Disable underline for the cells with underline attribute."
+  "When not-nil, underline text properties are ignored.
+
+This means that vterm will render underlined text as if it was not
+underlined."
   :type  'boolean
   :group 'vterm)
 
 (defcustom vterm-disable-inverse-video nil
-  "Disable inverse video for the cells with inverse video attribute."
+  "When not-nil, inverse video text properties are ignored.
+
+This means that vterm will render reversed video text as if it was not
+such."
   :type  'boolean
   :group 'vterm)
 
-(defcustom vterm-disable-bold-font nil
-  "Disable bold fonts or not.
+(define-obsolete-variable-alias 'vterm-disable-bold-font
+  'vterm-disable-bold "0.0.1")
 
-When `vterm-disable-bold-font' is set to t, bold fonts are
-rendered as normal ones."
+(defcustom vterm-disable-bold-font nil
+  "When not-nil, bold text properties are ignored.
+
+This means that vterm will render bold with the default face weight."
   :type  'boolean
   :group 'vterm)
 

--- a/vterm.el
+++ b/vterm.el
@@ -366,13 +366,6 @@ not require any shell-side configuration. See
 
 ;;; Faces
 
-(defface vterm-color-default
-  `((t :inherit default))
-  "The default normal color and bright color.
-The foreground color is used as ANSI color 0 and the background
-color is used as ANSI color 7."
-  :group 'vterm)
-
 (defface vterm-color-black
   `((t :inherit term-color-black))
   "Face used to render black color code.
@@ -430,13 +423,13 @@ color is used as ansi color 15."
   :group 'vterm)
 
 (defface vterm-color-underline
-  `((t :inherit vterm-color-default))
+  `((t :inherit default))
   "Face used to render cells with underline attribute.
 Only foreground is used."
   :group 'vterm)
 
 (defface vterm-color-inverse-video
-  `((t :inherit vterm-color-default))
+  `((t :inherit default))
   "Face used to render cells with inverse video attribute.
 Only background is used."
   :group 'vterm)
@@ -1167,8 +1160,6 @@ If N is negative backward-line from end of buffer."
   "Get color by index from `vterm-color-palette'.
 Argument INDEX index of the terminal color.
 Special values for INDEX are:
--1 means default foreground.
--2 for default background.
 -11 foreground for cells with underline attribute, foreground of
 the `vterm-color-underline' face is used in this case.
 -12 background for cells with inverse video attribute, background
@@ -1178,18 +1169,16 @@ of the `vterm-color-inverse-video' face is used in this case."
     (face-foreground
      (elt vterm-color-palette index)
      nil 'default))
-   ((and (>= index 8 ) (< index 16))
+   ((and (>= index 8) (< index 16))
     (face-background
      (elt vterm-color-palette (% index 8))
      nil 'default))
-   ((= index -1)               ;-1 foreground
-    (face-foreground 'vterm-color-default nil 'default))
    ((= index -11)
     (face-foreground 'vterm-color-underline nil 'default))
    ((= index -12)
     (face-background 'vterm-color-inverse-video nil 'default))
-   (t                                   ;-2 background
-    (face-background 'vterm-color-default nil 'default))))
+   (t
+    nil)))
 
 (defun vterm--eval (str)
   "Check if string STR is `vterm-eval-cmds' and execute command.


### PR DESCRIPTION
emacs-libvterm creates lots of text properties on each character. I propose to minimize them. In particular, with this patch `vterm--get-color` can return nil when the default face should be used, which is in general the case for most characters.