### PR TITLE
Fix customizing vterm-keymap-exceptions

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -222,8 +222,9 @@ function `vterm--exclude-keys' removes the keybindings defined in
   :type '(repeat string)
   :set (lambda (sym val)
          (set sym val)
-         (when (fboundp 'vterm--exclude-keys)
-           (vterm--exclude-keys val)))
+         (when (and (fboundp 'vterm--exclude-keys)
+		    (boundp 'vterm-mode-map))
+           (vterm--exclude-keys vterm-mode-map val)))
   :group 'vterm)
 
 (defcustom vterm-exit-functions nil


### PR DESCRIPTION
In b1ff04d43920927db36eef15e5bfa0f7a844ba47 `term--exclude-keys` got an additional argument but I forgot to update this caller accordingly.