### PR TITLE
 add some function vterm-delete-region and vterm-goto-char

### DIFF
--- a/vterm-module.c
+++ b/vterm-module.c
@@ -1384,7 +1384,7 @@ int emacs_module_init(struct emacs_runtime *ert) {
   Flist = env->make_global_ref(env, env->intern(env, "list"));
   Fnth = env->make_global_ref(env, env->intern(env, "nth"));
   Ferase_buffer = env->make_global_ref(env, env->intern(env, "erase-buffer"));
-  Finsert = env->make_global_ref(env, env->intern(env, "insert"));
+  Finsert = env->make_global_ref(env, env->intern(env, "vterm--insert"));
   Fgoto_char = env->make_global_ref(env, env->intern(env, "goto-char"));
   Fput_text_property =
       env->make_global_ref(env, env->intern(env, "put-text-property"));

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -1233,11 +1233,11 @@ emacs_value Fvterm_update(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
     unsigned char key[len];
     env->copy_string_contents(env, args[1], (char *)key, &len);
     VTermModifier modifier = VTERM_MOD_NONE;
-    if (env->is_not_nil(env, args[2]))
+    if (nargs > 2 && env->is_not_nil(env, args[2]))
       modifier = modifier | VTERM_MOD_SHIFT;
-    if (env->is_not_nil(env, args[3]))
+    if (nargs > 3 && env->is_not_nil(env, args[3]))
       modifier = modifier | VTERM_MOD_ALT;
-    if (env->is_not_nil(env, args[4]))
+    if (nargs > 4 && env->is_not_nil(env, args[4]))
       modifier = modifier | VTERM_MOD_CTRL;
 
     // Ignore the final zero byte

--- a/vterm.el
+++ b/vterm.el
@@ -778,7 +778,8 @@ will invert `vterm-copy-exclude-prompt' for that call."
       (when (and (not (symbolp last-input-event)) shift (not meta) (not ctrl))
         (setq key (upcase key)))
       (vterm--update vterm--term key shift meta ctrl)
-      (setq vterm--redraw-immididately t))))
+      (setq vterm--redraw-immididately t)
+       (accept-process-output vterm--process vterm-timer-delay nil t))))
 
 (defun vterm-send (key)
   "Send KEY to libvterm.  KEY can be anything `kbd' understands."
@@ -948,7 +949,8 @@ Optional argument PASTE-P paste-p."
       (vterm--update vterm--term (char-to-string char) nil nil nil))
     (when paste-p
       (vterm--update vterm--term "<end_paste>" nil nil nil)))
-  (setq vterm--redraw-immididately t))
+  (setq vterm--redraw-immididately t)
+  (accept-process-output vterm--process vterm-timer-delay nil t))
 
 ;;; Internal
 

--- a/vterm.el
+++ b/vterm.el
@@ -948,11 +948,11 @@ Argument ARG is passed to `yank'"
 Optional argument PASTE-P paste-p."
   (when vterm--term
     (when paste-p
-      (vterm--update vterm--term "<start_paste>" nil nil nil))
+      (vterm--update vterm--term "<start_paste>" ))
     (dolist (char (string-to-list string))
-      (vterm--update vterm--term (char-to-string char) nil nil nil))
+      (vterm--update vterm--term (char-to-string char)))
     (when paste-p
-      (vterm--update vterm--term "<end_paste>" nil nil nil)))
+      (vterm--update vterm--term "<end_paste>")))
   (setq vterm--redraw-immididately t)
   (accept-process-output vterm--process vterm-timer-delay nil t))
 
@@ -961,13 +961,13 @@ Optional argument PASTE-P paste-p."
 
 Provide similar behavior as `insert' for vterm."
   (when vterm--term
-    (vterm--update vterm--term "<start_paste>" nil nil nil)
+    (vterm--update vterm--term "<start_paste>")
     (dolist (c contents)
       (if (characterp c)
-          (vterm--update vterm--term (char-to-string c) nil nil nil)
+          (vterm--update vterm--term (char-to-string c))
         (dolist (char (string-to-list c))
-          (vterm--update vterm--term (char-to-string char) nil nil nil))))
-    (vterm--update vterm--term "<end_paste>" nil nil nil)
+          (vterm--update vterm--term (char-to-string char)))))
+    (vterm--update vterm--term "<end_paste>")
     (setq vterm--redraw-immididately t)
     (accept-process-output vterm--process vterm-timer-delay nil t)))
 

--- a/vterm.el
+++ b/vterm.el
@@ -918,18 +918,18 @@ prefix argument ARG or with \\[universal-argument]."
 
 Argument ARG is passed to `yank'."
   (interactive "P")
+  (vterm-goto-char (point))
   (let ((inhibit-read-only t))
-    (cl-letf (((symbol-function 'insert-for-yank)
-               #'(lambda (str) (vterm-send-string str t))))
+    (cl-letf (((symbol-function 'insert) #'vterm-insert))
       (yank arg))))
 
 (defun vterm-yank-primary ()
   "Yank text from the primary selection in vterm."
   (interactive)
+  (vterm-goto-char (point))
   (let ((inhibit-read-only t)
         (primary (gui-get-primary-selection)))
-    (cl-letf (((symbol-function 'insert-for-yank)
-               #'(lambda (str) (vterm-send-string str t))))
+    (cl-letf (((symbol-function 'insert) #'vterm-insert))
       (insert-for-yank primary))))
 
 (defun vterm-yank-pop (&optional arg)
@@ -937,10 +937,10 @@ Argument ARG is passed to `yank'."
 
 Argument ARG is passed to `yank'"
   (interactive "p")
+  (vterm-goto-char (point))
   (let ((inhibit-read-only t)
         (yank-undo-function #'(lambda (_start _end) (vterm-undo))))
-    (cl-letf (((symbol-function 'insert-for-yank)
-               #'(lambda (str) (vterm-send-string str t))))
+    (cl-letf (((symbol-function 'insert) #'vterm-insert))
       (yank-pop arg))))
 
 (defun vterm-send-string (string &optional paste-p)


### PR DESCRIPTION
`vterm-delete-region` is  `delete-region` for `vterm.

After this pull request is merge.
 It  would make it more  comfortable for `evil-mode` user .
related issues #313 #160  #156 

I don't know where to put these evil-mode related code, so just put it here, Any suggestions?

```
(defun vterm-evil-insert ()
  (interactive)
  (vterm-goto-char (point))
  (call-interactively #'evil-insert))

(defun vterm-evil-append ()
  (interactive)
  (vterm-goto-char (point))
  (call-interactively #'evil-append))

(defun vterm-evil-delete ()
  "Provide similar behavior as `evil-delete'."
  (interactive)
  (let ((inhibit-read-only t)
        )
    (cl-letf (((symbol-function #'delete-region) #'vterm-delete-region))
      (call-interactively 'evil-delete))))

(defun vterm-evil-change ()
  "Provide similar behavior as `evil-change'."
  (interactive)
  (let ((inhibit-read-only t))
    (cl-letf (((symbol-function #'delete-region) #'vterm-delete-region))
      (call-interactively 'evil-change))))

(defun my-vterm-hook()
  (evil-local-mode 1)
  (evil-define-key 'normal 'local "a" 'vterm-evil-append)
  (evil-define-key 'normal 'local "d" 'vterm-evil-delete)
  (evil-define-key 'normal 'local "i" 'vterm-evil-insert)
  (evil-define-key 'normal 'local "c" 'vterm-evil-change))

(add-hook 'vterm-mode-hook 'my-vterm-hook)

```