### PR TITLE
vterm-yank: fix wrong symbol-function call

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -920,7 +920,7 @@ Argument ARG is passed to `yank'."
   (interactive "P")
   (vterm-goto-char (point))
   (let ((inhibit-read-only t))
-    (cl-letf (((symbol-function 'insert) #'vterm-insert))
+    (cl-letf (((symbol-function 'insert-for-yank) #'vterm-insert))
       (yank arg))))
 
 (defun vterm-yank-primary ()
@@ -929,7 +929,7 @@ Argument ARG is passed to `yank'."
   (vterm-goto-char (point))
   (let ((inhibit-read-only t)
         (primary (gui-get-primary-selection)))
-    (cl-letf (((symbol-function 'insert) #'vterm-insert))
+    (cl-letf (((symbol-function 'insert-for-yank) #'vterm-insert))
       (insert-for-yank primary))))
 
 (defun vterm-yank-pop (&optional arg)
@@ -940,7 +940,7 @@ Argument ARG is passed to `yank'"
   (vterm-goto-char (point))
   (let ((inhibit-read-only t)
         (yank-undo-function #'(lambda (_start _end) (vterm-undo))))
-    (cl-letf (((symbol-function 'insert) #'vterm-insert))
+    (cl-letf (((symbol-function 'insert-for-yank) #'vterm-insert))
       (yank-pop arg))))
 
 (defun vterm-send-string (string &optional paste-p)


### PR DESCRIPTION
`vterm-yank` broke after the commit https://github.com/akermu/emacs-libvterm/commit/f21d0dd1abc26ae447736c978cb2ea942627cd90 due to wrong `symbol-function` call (`insert` instead of `insert-for-yank`)

This pull request fixes the issue 🏆 