### PR TITLE
Fix vterm_printf tmux escape sequence pass through

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ readme.
 For `bash` or `zsh`, put this in your `.zshrc` or `.bashrc`
 ```bash
 vterm_printf(){
-    if [ -n "$TMUX" ]; then
+    if [ -n "$TMUX" ] && ([ "${TERM%%-*}" = "tmux" ] || [ "${TERM%%-*}" = "screen" ] ); then
         # Tell tmux to pass the escape sequences through
         printf "\ePtmux;\e\e]%s\007\e\\" "$1"
     elif [ "${TERM%%-*}" = "screen" ]; then
@@ -258,7 +258,7 @@ This works also for `dash`.
 For `fish` put this in your `~/.config/fish/config.fish`:
 ```bash
 function vterm_printf;
-    if [ -n "$TMUX" ]
+    if begin; [  -n "$TMUX" ]  ; and  string match -q -r "screen|tmux" "$TERM"; end 
         # tell tmux to pass the escape sequences through
         printf "\ePtmux;\e\e]%s\007\e\\" "$argv"
     else if string match -q -- "screen*" "$TERM"

--- a/etc/emacs-vterm-bash.sh
+++ b/etc/emacs-vterm-bash.sh
@@ -4,7 +4,7 @@
 # function that helps in this task, `vterm_printf`, is defined below.
 
 function vterm_printf(){
-    if [ -n "$TMUX" ]; then
+    if [ -n "$TMUX" ] && ([ "${TERM%%-*}" = "tmux" ] || [ "${TERM%%-*}" = "screen" ] ); then
         # Tell tmux to pass the escape sequences through
         printf "\ePtmux;\e\e]%s\007\e\\" "$1"
     elif [ "${TERM%%-*}" = "screen" ]; then

--- a/etc/emacs-vterm-zsh.sh
+++ b/etc/emacs-vterm-zsh.sh
@@ -4,7 +4,7 @@
 # function that helps in this task, `vterm_printf`, is defined below.
 
 function vterm_printf(){
-    if [ -n "$TMUX" ]; then
+    if [ -n "$TMUX" ] && ([ "${TERM%%-*}" = "tmux" ] || [ "${TERM%%-*}" = "screen" ] ); then
         # Tell tmux to pass the escape sequences through
         printf "\ePtmux;\e\e]%s\007\e\\" "$1"
     elif [ "${TERM%%-*}" = "screen" ]; then

--- a/etc/emacs-vterm.fish
+++ b/etc/emacs-vterm.fish
@@ -4,7 +4,7 @@
 # function that helps in this task, `vterm_printf`, is defined below.
 
 function vterm_printf;
-    if [ -n "$TMUX" ]
+    if begin; [  -n "$TMUX" ]  ; and  string match -q -r "screen|tmux" "$TERM"; end 
         # tell tmux to pass the escape sequences through
         printf "\ePtmux;\e\e]%s\007\e\\" "$argv"
     else if string match -q -- "screen*" "$TERM"


### PR DESCRIPTION
tmux requires that `TERM` is set to `screen*` or `tmux*` for subshells running inside tmux. See https://github.com/tmux/tmux/wiki/FAQ

Using this, I was able to change the `vterm_printf` passthrough switch such that it is not activated if Emacs and vterm are running **within** a tmux session. The passthrough still functions for running tmux within Emacs and vterm.

I have not yet tested the changes to the Fish shell-side configuration. 

Closes #443. 