### PR TITLE
restore behaviour of /usr/bin/clear command

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,39 +304,9 @@ the prompt and not include it in the copy.
 
 `vterm-clear-scrollback` does exactly what the name suggests: it clears the
 current buffer from the data that it is not currently visible.
-`vterm-clear-scrollback` is bound to `C-c C-l`. This function is typically used
-with the `clear` function provided by the shell to clear both screen and
-scrollback. In order to achieve this behavior, you need to add a new shell alias.
+`vterm-clear-scrollback` is bound to `C-c C-l`.
 
-For `zsh`, put this in your `.zshrc`:
-```zsh
-
-if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-    alias clear='vterm_printf "51;Evterm-clear-scrollback";tput clear'
-fi
-```
-For `bash`, put this in your `.bashrc`:
-```bash
-if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-    function clear(){
-        vterm_printf "51;Evterm-clear-scrollback";
-        tput clear;
-    }
-fi
-```
-For `fish`:
-```
-if [ "$INSIDE_EMACS" = 'vterm' ]
-    function clear
-        vterm_printf "51;Evterm-clear-scrollback";
-        tput clear;
-    end
-end
-```
-These aliases take advantage of the fact that `vterm` can execute `elisp`
-commands, as explained below.
-
-If it possible to automatically clear the scrollback when the screen is cleared
+It is possible to automatically clear the scrollback when the screen is cleared
 by setting the variable `vterm-clear-scrollback-when-clearing`: When
 `vterm-clear-scrollback-when-clearing` is non nil, `C-l` clears both the screen
 and the scrollback. When is nil, `C-l` only clears the screen. The opposite

--- a/etc/emacs-vterm-bash.sh
+++ b/etc/emacs-vterm-bash.sh
@@ -15,15 +15,6 @@ function vterm_printf(){
     fi
 }
 
-# Completely clear the buffer. With this, everything that is not on screen
-# is erased.
-if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-    function clear(){
-        vterm_printf "51;Evterm-clear-scrollback";
-        tput clear;
-    }
-fi
-
 # With vterm_cmd you can execute Emacs commands directly from the shell.
 # For example, vterm_cmd message "HI" will print "HI".
 # To enable new commands, you have to customize Emacs's variable

--- a/etc/emacs-vterm-zsh.sh
+++ b/etc/emacs-vterm-zsh.sh
@@ -15,12 +15,6 @@ function vterm_printf(){
     fi
 }
 
-# Completely clear the buffer. With this, everything that is not on screen
-# is erased.
-if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-    alias clear='vterm_printf "51;Evterm-clear-scrollback";tput clear'
-fi
-
 # With vterm_cmd you can execute Emacs commands directly from the shell.
 # For example, vterm_cmd message "HI" will print "HI".
 # To enable new commands, you have to customize Emacs's variable

--- a/etc/emacs-vterm.fish
+++ b/etc/emacs-vterm.fish
@@ -15,15 +15,6 @@ function vterm_printf;
     end
 end
 
-# Completely clear the buffer. With this, everything that is not on screen
-# is erased.
-if [ "$INSIDE_EMACS" = 'vterm' ]
-    function clear
-        vterm_printf "51;Evterm-clear-scrollback";
-        tput clear;
-    end
-end
-
 # This is to change the title of the buffer based on information provided by the
 # shell. See, http://tldp.org/HOWTO/Xterm-Title-4.html, for the meaning of the
 # various symbols.


### PR DESCRIPTION
`clear` is meant to clear screen, not clear display which clear scrollback buffer too.

And unfortunately fish shell binds `Ctrl-L` to `clear` command, so `Ctrl-L` always clear
scrollback buffer if `emacs-vterm.fish` is sourced, this is very surprising.

Further more, both original `clear` command and `Ctrl-L` don't clear scrollback buffer
in iTerm2 and Terminal.app.

References:

1. `man clear` shows "clear the terminal screen".

2. In bash, `bind -p | grep C-l` shows:
```
    "\e\C-l": clear-display
    "\C-l": clear-screen
```

3. In zsh, `bindkey | fgrep '^L'` shows:
```
    "^L" clear-screen
    "^[^L" clear-screen
```

4. In fish, `bind -a | fgrep '\cl'` shows:
```
    bind --preset \cl echo\ -n\ \(clear\ \|\ string\ replace\ \\e\\\[3J\ \"\"\)\;\ commandline\ -f\ repaint
```

@jixiuf 