### PR TITLE
fix cursor type after hide cursor and show again

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,13 @@ In addition to that, you can disable some text properties (bold, underline,
 reverse video) setting the relative option to `t` (`vterm-disable-bold`,
 `vterm-disable-underline`, or `vterm-disable-inverse-video`).
 
+## Blink cursor
+
+When `vterm-ignore-blink-cursor` is `t`, vterm will ignore request from application to turn on or off cursor blink.
+
+If `nil`, cursor in any window may begin to blink or not blink because `blink-cursor-mode`
+is a global minor mode in Emacs, you can use `M-x blink-cursor-mode` to toggle.
+
 ## Colors
 
 Set the `:foreground` and `:background` attributes of the following faces to a

--- a/elisp.c
+++ b/elisp.c
@@ -26,6 +26,7 @@ emacs_value Qrear_nonsticky;
 emacs_value Qvterm_prompt;
 
 // Emacs functions
+emacs_value Fblink_cursor_mode;
 emacs_value Fsymbol_value;
 emacs_value Flength;
 emacs_value Flist;
@@ -172,8 +173,12 @@ emacs_value selected_window(emacs_env *env) {
   return env->funcall(env, Fselected_window, 0, (emacs_value[]){});
 }
 
-void set_cursor_type(emacs_env *env, emacs_value QCursorType) {
-  env->funcall(env, Fset, 2, (emacs_value[]){Qcursor_type, QCursorType});
+void set_cursor_type(emacs_env *env, emacs_value cursor_type) {
+  env->funcall(env, Fset, 2, (emacs_value[]){Qcursor_type, cursor_type});
+}
+
+void set_cursor_blink(emacs_env *env, bool blink) {
+  env->funcall(env, Fblink_cursor_mode, 1, (emacs_value[]){env->make_integer(env, blink)});
 }
 
 emacs_value vterm_get_color(emacs_env *env, int index) {

--- a/elisp.h
+++ b/elisp.h
@@ -29,6 +29,7 @@ extern emacs_value Qrear_nonsticky;
 extern emacs_value Qvterm_prompt;
 
 // Emacs functions
+extern emacs_value Fblink_cursor_mode;
 extern emacs_value Fsymbol_value;
 extern emacs_value Flength;
 extern emacs_value Flist;
@@ -77,6 +78,7 @@ void goto_char(emacs_env *env, int pos);
 void forward_line(emacs_env *env, int n);
 void goto_line(emacs_env *env, int n);
 void set_cursor_type(emacs_env *env, emacs_value cursor_type);
+void set_cursor_blink(emacs_env *env, bool blink);
 void delete_lines(emacs_env *env, int linenum, int count, bool del_whole_line);
 void recenter(emacs_env *env, emacs_value pos);
 void set_window_point(emacs_env *env, emacs_value win, emacs_value point);

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -30,14 +30,6 @@ typedef struct ScrollbackLine {
   VTermScreenCell cells[];
 } ScrollbackLine;
 
-enum {
-  VTERM_PROP_CURSOR_BLOCK = VTERM_PROP_CURSORSHAPE_BLOCK,
-  VTERM_PROP_CURSOR_UNDERLINE = VTERM_PROP_CURSORSHAPE_UNDERLINE,
-  VTERM_PROP_CURSOR_BAR_LEFT = VTERM_PROP_CURSORSHAPE_BAR_LEFT,
-  VTERM_PROP_CURSOR_VISIBLE = 4,
-  VTERM_PROP_CURSOR_NOT_VISIBLE = 5,
-};
-
 /*  c , p , q , s , 0 , 1 , 2 , 3 , 4 , 5 , 6 , and 7  */
 /* clipboard, primary, secondary, select, or cut buffers 0 through 7 */
 #define SELECTION_TARGET_MAX 12
@@ -45,7 +37,10 @@ enum {
 typedef struct Cursor {
   int row, col;
   int cursor_type;
+  bool cursor_visible;
+  bool cursor_blink;
   bool cursor_type_changed;
+  bool cursor_blink_changed;
 } Cursor;
 
 typedef struct Term {
@@ -94,6 +89,7 @@ typedef struct Term {
   bool disable_bold_font;
   bool disable_underline;
   bool disable_inverse_video;
+  bool ignore_blink_cursor;
 
   char *cmd_buffer;
 

--- a/vterm.el
+++ b/vterm.el
@@ -339,6 +339,14 @@ This means that vterm will render bold with the default face weight."
   :type  'boolean
   :group 'vterm)
 
+(defcustom vterm-ignore-blink-cursor t
+  "When t, vterm will ignore request from application to turn on or off cursor blink.
+
+If nil, cursor in any window may begin to blink or not blink because `blink-cursor-mode`
+is a global minor mode in Emacs, you can use `M-x blink-cursor-mode` to toggle."
+  :type 'boolean
+  :group 'vterm)
+
 (defcustom vterm-copy-exclude-prompt t
   "When not-nil, the prompt is not included by `vterm-copy-mode-done'."
   :type 'boolean
@@ -627,7 +635,8 @@ Exceptions are defined by `vterm-keymap-exceptions'."
                                   width vterm-max-scrollback
                                   vterm-disable-bold-font
                                   vterm-disable-underline
-                                  vterm-disable-inverse-video))
+                                  vterm-disable-inverse-video
+                                  vterm-ignore-blink-cursor))
     (setq buffer-read-only t)
     (setq-local scroll-conservatively 101)
     (setq-local scroll-margin 0)


### PR DESCRIPTION
This patch also adds support for cursor blink.

VIM emits these ANSI escape sequences in insert mode:
```
    \x1b[?25h   show cursor
    \x1b[?25l   hide cursor
```

You may add these to ~/.vimrc to verify it:
```
" https://vim.fandom.com/wiki/Change_cursor_shape_in_different_modes
" Cursor settings:
"  1 -> blinking block
"  2 -> solid block 
"  3 -> blinking underscore
"  4 -> solid underscore
"  5 -> blinking vertical bar
"  6 -> solid vertical bar
let &t_SI="\e[5 q"
let &t_SR="\e[3 q"
let &t_EI="\e[1 q"
```

@jixiuf 