### PR TITLE
Put module compilation buffer in compilation mode

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -122,7 +122,9 @@ the executable."
              cd -"))
            (buffer (get-buffer-create vterm-install-buffer-name)))
       (pop-to-buffer buffer)
-      (if (zerop (call-process "sh" nil buffer t "-c" make-commands))
+      (compilation-mode)
+      (if (zerop (let ((inhibit-read-only t))
+                   (call-process "sh" nil buffer t "-c" make-commands)))
           (message "Compilation of `emacs-libvterm' module succeeded")
         (error "Compilation of `emacs-libvterm' module failed!")))))
 


### PR DESCRIPTION
So the buffer is quittable by pressing q, and the compilation warnings and errors are navigable