### PR TITLE
Fix xterm-paste in vterm.

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -537,6 +537,14 @@ Exceptions are defined by `vterm-keymap-exceptions'."
                                  unless (member key exceptions)
                                  collect key))))
 
+(defun vterm-xterm-paste (event)
+  "Handle xterm paste EVENT in vterm."
+  (interactive "e")
+  (with-temp-buffer
+    (xterm-paste event)
+    (kill-new (buffer-string)))
+  (vterm-yank))
+
 (defvar vterm-mode-map
   (let ((map (make-sparse-keymap)))
     (vterm--exclude-keys map vterm-keymap-exceptions)
@@ -574,7 +582,7 @@ Exceptions are defined by `vterm-keymap-exceptions'."
     (define-key map [C-end]                     #'vterm--self-insert)
     (define-key map [escape]                    #'vterm--self-insert)
     (define-key map [remap yank]                #'vterm-yank)
-    (define-key map [remap xterm-paste]         #'vterm-yank)
+    (define-key map [remap xterm-paste]         #'vterm-xterm-paste)
     (define-key map [remap yank-pop]            #'vterm-yank-pop)
     (define-key map [remap mouse-yank-primary]  #'vterm-yank-primary)
     (define-key map (kbd "C-SPC")               #'vterm--self-insert)


### PR DESCRIPTION
Vterm-yank does not copy from the system clipboard that is supported
via xterm.el. This patch fixes it.