### PR TITLE
Handle translated keys correctly and fix keypad keys.

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -788,11 +788,11 @@ will invert `vterm-copy-exclude-prompt' for that call."
   "Send invoking key to libvterm."
   (interactive)
   (when vterm--term
-    (let* ((modifiers (event-modifiers last-input-event))
+    (let* ((modifiers (event-modifiers last-command-event))
            (shift (memq 'shift modifiers))
            (meta (memq 'meta modifiers))
            (ctrl (memq 'control modifiers))
-           (raw-key (event-basic-type last-input-event))
+           (raw-key (event-basic-type last-command-event))
            (ev-key (if input-method-function
                        (let ((inhibit-read-only t))
                          (funcall input-method-function raw-key))
@@ -806,7 +806,7 @@ will invert `vterm-copy-exclude-prompt' for that call."
   (when vterm--term
     (let ((inhibit-redisplay t)
           (inhibit-read-only t))
-      (when (and (not (symbolp last-input-event)) shift (not meta) (not ctrl))
+      (when (and (not (symbolp last-command-event)) shift (not meta) (not ctrl))
         (setq key (upcase key)))
       (vterm--update vterm--term key shift meta ctrl)
       (setq vterm--redraw-immididately t)


### PR DESCRIPTION
As I still experience issue #202, I have looked into the code of `self-insert-command` to look for any differences in how translated keys are handled. I’ve found that `self-insert-command` uses `last-command-event` to determine the pressed key, while `vterm--self-insert` and `vterm-send-key` use `last-input-event`. I’ve changed the `vterm` functions to use `last-command-event`, which makes them handle translated keys properly and fixes the issue for me.

To highlight the differences (as far as I understand them), let’s take a look at `<kp-add>`.

1. The user presses `<kp-add>`.
2. `last-input-event` is set to `<kp-add>`.
3. No command is bound to `<kp-add>`.
4. `<kp-add>` gets translated to `+` using `key-translation-map`.
5. The command `self-insert-command`/`vterm--self-insert` is bound to `+`.
6. `last-command-event` is set to `+`.
7. `self-insert-command`/`vterm--self-insert` is called.
8. `self-insert-command` tries to insert `last-command-event` which is `+`.
8. `vterm--self-insert` tries to insert `last-input-event` which is `<kp-add>` **not** `+`.

This PR:
- Makes `vterm.el` handle translated keys correctly.
- Fixes #202 once-and-for-all.
- Fixes the [outstanding issues with #203](https://github.com/akermu/emacs-libvterm/pull/203#issuecomment-567226996).
- Makes #203 obsolete.

