### PR TITLE
vterm-module-compile: Enforce 'Unix Makefiles' for CMake

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -117,7 +117,7 @@ the executable."
              "cd " vterm-directory "; \
              mkdir -p build; \
              cd build; \
-             cmake "
+             cmake -G 'Unix Makefiles'"
              vterm-module-cmake-args
              " ..; \
              make; \


### PR DESCRIPTION
CMake generates build files for the system defined as `$CMAKE_GENERATOR`. For instance, I use `ninja` as my default generator. Since CMake supports multiple build systems, the following should normally be used:

```sh
cmake ..
cmake --build .
```

`vterm-module-compile` instead assumes that CMake generates Makefile, and runs `make` directly, which will fail if the user has specified a different `CMAKE_GENERATOR`.

However, using `Ninja` fails in our case because `libvterm` is a Makefile project, and Ninja does not know how to build it. This entire thing can be resolved by enforcing Make with CMake:

```sh
cmake -G 'Unix Makefiles' ..
make
```