### PR TITLE
Exclude "C-M-" "C-M-S-" keys

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -551,6 +551,13 @@ Exceptions are defined by `vterm-keymap-exceptions'."
                  append (cl-loop for char from ?a to ?z
                                  for key = (format "%s%c" prefix char)
                                  unless (member key exceptions)
+                                 collect key)))
+  (mapc (lambda (key)
+          (define-key map (kbd key) 'ignore))
+        (cl-loop for prefix in '("C-M-" "C-M-S-")
+                 append (cl-loop for char from ?a to ?z
+                                 for key = (format "%s%c" prefix char)
+                                 unless (member key exceptions)
                                  collect key))))
 
 (defun vterm-xterm-paste (event)


### PR DESCRIPTION
`C-M-f/b` move cursor forward/backward an S-expression in buffer, but not in vterm, which could cause confusion.
So we exclude those keys. (By binding them to `'ignore`)