### PR TITLE
Add missing space before vterm-module-cmake-args

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -117,7 +117,7 @@ the executable."
              "cd " vterm-directory "; \
              mkdir -p build; \
              cd build; \
-             cmake -G 'Unix Makefiles'"
+             cmake -G 'Unix Makefiles' "
              vterm-module-cmake-args
              " ..; \
              make; \


### PR DESCRIPTION
After commit 060910425b77660503ec248fb1c383df40eec758, setting
vterm-module-cmake-args without including a leading space will typically
result in an error like:

  CMake Error: Could not create named generator Unix Makefiles-DUSE_SYSTEM_LIBVTERM=yes

If vterm-module-cmake-args is an empty string (the default) everything
still works.

Fix it by adding a space between the cmake generator name and
vterm-module-cmake-args.