### PR TITLE
Fix incorrect terminal width when using vterm-other-window

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -1191,10 +1191,10 @@ value of `vterm-buffer-name'."
                    (t
                     (get-buffer-create vterm-buffer-name)))))
     (cl-assert (and buf (buffer-live-p buf)))
+    (funcall pop-to-buf-fun buf)
     (with-current-buffer buf
       (unless (derived-mode-p 'vterm-mode)
-        (vterm-mode)))
-    (funcall pop-to-buf-fun buf)))
+        (vterm-mode)))))
 
 ;;; Internal
 


### PR DESCRIPTION
This fixes incorrect terminal width when using `vterm-other-window`.

Vterm sets terminal width in `vterm-mode` by calling `window-body-width`.
If we call `vterm-mode` before terminal window creation,
it would actually get previous window's width.