### PR TITLE
Support custom `vterm-copy-mode-map`

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -772,7 +772,7 @@ A conventient way to exit `vterm-copy-mode' is with
   (if (equal major-mode 'vterm-mode)
       (if vterm-copy-mode
           (progn                            ;enable vterm-copy-mode
-            (use-local-map nil)
+            (use-local-map vterm-copy-mode-map)
             (vterm-send-stop))
         (vterm-reset-cursor-point)
         (use-local-map vterm-mode-map)


### PR DESCRIPTION
Not sure if this is correct or required, but without this change, I haven't been able to figure out a way to apply a customized `vterm-copy-mode-map`.