### PR TITLE
Update documentation for Debian versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Before installing emacs-libvterm, you need to make sure you have installed
     (e.g., Arch, Debian, Fedora, Gentoo, openSUSE, Ubuntu). Typical names are
     `libvterm` (Arch, Fedora, Gentoo, openSUSE), or `libvterm-dev` (Debian,
     Ubuntu). If not available, `libvterm` will be downloaded during the
-    compilation process. Some distributions (e.g. Ubuntu < 20.04, Debian Stable)
+    compilation process. Some distributions (e.g. Ubuntu < 20.04, Debian < 11)
     have versions of `libvterm` that are too old. If you find compilation errors
     related to `VTERM_COLOR`, you should not use your system libvterm. See
     [FAQ](#frequently-asked-questions-and-problems) for more details.


### PR DESCRIPTION
Debian 11 is now stable and currently has 0.1.4-1 of libvterm-dev in packages.