### PR TITLE
Add nested tmux escape sequence for bash prompt tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,8 +243,12 @@ For `bash` or `zsh`, put this in your `.zshrc` or `.bashrc`
 ```bash
 vterm_printf(){
     if [ -n "$TMUX" ] && ([ "${TERM%%-*}" = "tmux" ] || [ "${TERM%%-*}" = "screen" ] ); then
-        # Tell tmux to pass the escape sequences through
-        printf "\ePtmux;\e\e]%s\007\e\\" "$1"
+        # Tell both simple and nested tmux to pass the escape sequences through
+        # There is no easy way to detect nested tmux (expecially over ssh), so
+        # it is more user friendly to enable the nested version by default
+        printf '\ePtmux;\e\ePtmux;\e\e\e\e]%s\a\e\e\\\e\' "$1"
+        # Uncomment the fllowing to enable the simple version:
+        # printf "\ePtmux;\e\e]%s\007\e\\" "$1"
     elif [ "${TERM%%-*}" = "screen" ]; then
         # GNU screen (screen, screen-256color, screen-256color-bce)
         printf "\eP\e]%s\007\e\\" "$1"

--- a/etc/emacs-vterm-bash.sh
+++ b/etc/emacs-vterm-bash.sh
@@ -5,8 +5,12 @@
 
 function vterm_printf(){
     if [ -n "$TMUX" ] && ([ "${TERM%%-*}" = "tmux" ] || [ "${TERM%%-*}" = "screen" ] ); then
-        # Tell tmux to pass the escape sequences through
-        printf "\ePtmux;\e\e]%s\007\e\\" "$1"
+        # Tell both simple and nested tmux to pass the escape sequences through
+        # There is no easy way to detect nested tmux (expecially over ssh), so
+        # it is more user friendly to enable the nested version by default
+        printf '\ePtmux;\e\ePtmux;\e\e\e\e]%s\a\e\e\\\e\' "$1"
+        # Uncomment the fllowing to enable the simple version:
+        # printf "\ePtmux;\e\e]%s\007\e\\" "$1"
     elif [ "${TERM%%-*}" = "screen" ]; then
         # GNU screen (screen, screen-256color, screen-256color-bce)
         printf "\eP\e]%s\007\e\\" "$1"


### PR DESCRIPTION
The single tmux instances are unaffected by the change.

The implementation uses the single quote to simplify the escaping of
backslashes (avoid doubling them) and replaces the octal value of the
bell sequence (\007) with the corresponding C escape sequence (\a) for
uniformity with ESC (\033 or \e).