### PR TITLE
Do not export unnecessary symbols in dynamic library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ endif()
 add_library(vterm-module MODULE vterm-module.c utf8.c elisp.c)
 set_target_properties(vterm-module PROPERTIES
   C_STANDARD 99
+  C_VISIBILITY_PRESET "hidden"
   POSITION_INDEPENDENT_CODE ON
   PREFIX ""
   LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -6,7 +6,22 @@
 #include <stdbool.h>
 #include <vterm.h>
 
-int plugin_is_GPL_compatible;
+// https://gcc.gnu.org/wiki/Visibility
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define VTERM_EXPORT __attribute__ ((dllexport))
+  #else
+    #define VTERM_EXPORT __declspec(dllexport)
+  #endif
+#else
+  #if __GNUC__ >= 4
+    #define VTERM_EXPORT __attribute__ ((visibility ("default")))
+  #else
+    #define VTERM_EXPORT
+  #endif
+#endif
+
+VTERM_EXPORT int plugin_is_GPL_compatible;
 
 #define SB_MAX 100000 // Maximum 'scrollback' value.
 
@@ -147,6 +162,6 @@ emacs_value Fvterm_get_prompt_point(emacs_env *env, ptrdiff_t nargs,
 emacs_value Fvterm_reset_cursor_point(emacs_env *env, ptrdiff_t nargs,
                                       emacs_value args[], void *data);
 
-int emacs_module_init(struct emacs_runtime *ert);
+VTERM_EXPORT int emacs_module_init(struct emacs_runtime *ert);
 
 #endif /* VTERM_MODULE_H */


### PR DESCRIPTION
Fixes https://github.com/akermu/emacs-libvterm/issues/559

As commented in https://github.com/akermu/emacs-libvterm/issues/559#issuecomment-992681062, emacs crashes when loading vterm-module.so because the address of `Qt` is incorrectly resolved to the read-only symbol in `emacs` binary. I can verify this with `LD_DEBUG=all`:

```
     75570:     binding file .../.emacs.d/straight/build/vterm/vterm-module.so [0] to ./src/emacs [0]: normal symbol `Qt'
```

This PR hides all symbols except two necessary ones, so that the symbols like `Qt` will be resolved correctly.

I'm still unclear about the root cause: I thought `RTLD_LOCAL` should be the default behavior for `dlopen` so this should not happen; It's also strange that this only happens when building with `--with-xwidgets`, maybe loading xwidgets somehow affects the order of the symbol resolution. But anyway, this fix works and I don't think if there's any downside of it.
