### PR TITLE
fix: add an INSIDE_EMACS guard to vterm_prompt_end

### DIFF
--- a/etc/emacs-vterm-zsh.sh
+++ b/etc/emacs-vterm-zsh.sh
@@ -22,7 +22,7 @@ if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
 fi
 
 # With vterm_cmd you can execute Emacs commands directly from the shell.
-# For example, vterm_cmd message "HI" will print "HI"..
+# For example, vterm_cmd message "HI" will print "HI".
 # To enable new commands, you have to customize Emacs's variable
 # vterm-eval-cmds.
 vterm_cmd() {

--- a/etc/emacs-vterm-zsh.sh
+++ b/etc/emacs-vterm-zsh.sh
@@ -22,7 +22,7 @@ if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
 fi
 
 # With vterm_cmd you can execute Emacs commands directly from the shell.
-# For example, vterm_cmd message "HI" will print "HI".
+# For example, vterm_cmd message "HI" will print "HI"..
 # To enable new commands, you have to customize Emacs's variable
 # vterm-eval-cmds.
 vterm_cmd() {
@@ -48,7 +48,9 @@ add-zsh-hook -Uz chpwd (){ print -Pn "\e]2;%m:%2~\a" }
 # The escape sequence "51;A" has also the role of identifying the end of the
 # prompt
 vterm_prompt_end() {
-    vterm_printf "51;A$(whoami)@$(hostname):$(pwd)";
+    if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
+        vterm_printf "51;A$(whoami)@$(hostname):$(pwd)";
+    fi
 }
 setopt PROMPT_SUBST
 PROMPT=$PROMPT'%{$(vterm_prompt_end)%}'


### PR DESCRIPTION
Without the guard, the shell prompt in buffers that are _not_ `vterm` ends up being messed up.
For example, if I do `M-x shell`, the shell prompt is messed up.