### PR TITLE
fix: add INSIDE_EMACS guards for vterm_prompt_end

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,7 +525,9 @@ For `zsh`, put this at the end of your `.zshrc`:
 
 ```zsh
 vterm_prompt_end() {
-    vterm_printf "51;A$(whoami)@$(hostname):$(pwd)";
+    if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
+        vterm_printf "51;A$(whoami)@$(hostname):$(pwd)";
+    fi
 }
 setopt PROMPT_SUBST
 PROMPT=$PROMPT'%{$(vterm_prompt_end)%}'
@@ -535,7 +537,9 @@ For `bash`, put this at the end of your `.bashrc`:
 
 ```bash
 vterm_prompt_end(){
-    vterm_printf "51;A$(whoami)@$(hostname):$(pwd)"
+    if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
+        vterm_printf "51;A$(whoami)@$(hostname):$(pwd)";
+    fi
 }
 PS1=$PS1'\[$(vterm_prompt_end)\]'
 ```
@@ -544,7 +548,9 @@ For `fish`, put this in your `~/.config/fish/config.fish`:
 
 ```fish
 function vterm_prompt_end;
-    vterm_printf '51;A'(whoami)'@'(hostname)':'(pwd)
+    if [ "$INSIDE_EMACS" = 'vterm' ]
+        vterm_printf '51;A'(whoami)'@'(hostname)':'(pwd)
+    end
 end
 functions --copy fish_prompt vterm_old_fish_prompt
 function fish_prompt --description 'Write out the prompt; do not replace this. Instead, put this at end of your file.'

--- a/etc/emacs-vterm-bash.sh
+++ b/etc/emacs-vterm-bash.sh
@@ -17,12 +17,10 @@ function vterm_printf(){
 
 # Completely clear the buffer. With this, everything that is not on screen
 # is erased.
-if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-    function clear(){
-        vterm_printf "51;Evterm-clear-scrollback";
-        tput clear;
-    }
-fi
+function clear(){
+    vterm_printf "51;Evterm-clear-scrollback";
+    tput clear;
+}
 
 # With vterm_cmd you can execute Emacs commands directly from the shell.
 # For example, vterm_cmd message "HI" will print "HI".

--- a/etc/emacs-vterm-zsh.sh
+++ b/etc/emacs-vterm-zsh.sh
@@ -17,9 +17,7 @@ function vterm_printf(){
 
 # Completely clear the buffer. With this, everything that is not on screen
 # is erased.
-if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-    alias clear='vterm_printf "51;Evterm-clear-scrollback";tput clear'
-fi
+alias clear='vterm_printf "51;Evterm-clear-scrollback";tput clear'
 
 # With vterm_cmd you can execute Emacs commands directly from the shell.
 # For example, vterm_cmd message "HI" will print "HI".

--- a/etc/emacs-vterm.fish
+++ b/etc/emacs-vterm.fish
@@ -17,13 +17,11 @@ end
 
 # Completely clear the buffer. With this, everything that is not on screen
 # is erased.
-if [ "$INSIDE_EMACS" = 'vterm' ]
-    function clear
-        vterm_printf "51;Evterm-clear-scrollback";
-        tput clear;
-    end
+function clear
+    vterm_printf "51;Evterm-clear-scrollback";
+    tput clear;
 end
-
+    
 # This is to change the title of the buffer based on information provided by the
 # shell. See, http://tldp.org/HOWTO/Xterm-Title-4.html, for the meaning of the
 # various symbols.

--- a/etc/emacs-vterm.fish
+++ b/etc/emacs-vterm.fish
@@ -21,7 +21,7 @@ function clear
     vterm_printf "51;Evterm-clear-scrollback";
     tput clear;
 end
-    
+
 # This is to change the title of the buffer based on information provided by the
 # shell. See, http://tldp.org/HOWTO/Xterm-Title-4.html, for the meaning of the
 # various symbols.


### PR DESCRIPTION
Add `INSIDE_EMACS` guard to `vterm_prompt_end` to avoid messing up the prompt for shells that are _not_ running in `vterm` (e.g., started via `M-x shell`).