### PR TITLE
Add send-next-key function

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,6 +455,18 @@ or remove it from `vterm-mode-map`. By default, `vterm.el` binds most of the
 like `<backspace>` and `<return>`. Sending a keyboard interrupt is bound to `C-c
 C-c`.
 
+In order to send a keypress that is already recognized by Emacs, such as `C-g`,
+use the interactive function `vterm-send-next-key`. This can be bound to a key
+in the `vterm-mode-map` like `C-q`, in which case pressing `C-q C-g` will send a
+`C-g` key to the terminal, and so on for other modified keys:
+
+``` emacs
+(define-key vterm-mode-map (kbd "C-q") #'vterm-send-next-key)
+```
+
+This can be useful for controlling an application running in the terminal, such
+as Emacs or Nano.
+
 ## Fonts
 
 You can change the font (the _face_) used in a vterm with the following code:

--- a/vterm.el
+++ b/vterm.el
@@ -922,6 +922,23 @@ will invert `vterm-copy-exclude-prompt' for that call."
                     (memq 'meta modifiers)
                     (memq 'control modifiers))))
 
+(defun vterm-send-next-key ()
+  "Read next input event and send it to the libvterm.
+
+With this you can directly send modified keys to applications
+running in the terminal (like Emacs or Nano)."
+  (interactive)
+  (let* ((inhibit-quit t)
+         (event (read-event))
+         (inhibit-quit nil)
+         (modifiers (event-modifiers event))
+         (basic (event-basic-type event)))
+    (if (characterp basic)
+        (vterm-send-key (string basic)
+                        (memq 'shift modifiers)
+                        (memq 'meta modifiers)
+                        (memq 'control modifiers)))))
+  
 (defun vterm-send-start ()
   "Output from the system is started when the system receives START."
   (interactive)


### PR DESCRIPTION
Read next input event and send it to the libvterm.

This is useful for controlling an emacs session within emacs-libvterm.