### PR TITLE
Silence byte-compiler

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -1169,7 +1169,7 @@ the return value is `t' when cursor moved."
            (get-text-property (1- (point)) 'vterm-line-wrap))
       t)
      ((and (= (point) (+ 4 pt))
-           (looking-back (regexp-quote "^[[C"))) ;escape code for <right>
+           (looking-back (regexp-quote "^[[C") nil)) ;escape code for <right>
       (dotimes (_ 3) (vterm-send-key "<backspace>" nil nil nil t)) ;;delete  "^[[C"
       nil)
      ((> (point) (1+ pt))             ;auto suggest
@@ -1195,7 +1195,7 @@ Return count of moved characeters."
                          "\n"))
       t)
      ((and (= (point) (+ 4 pt))
-           (looking-back (regexp-quote "^[[D"))) ;escape code for <left>
+           (looking-back (regexp-quote "^[[D") nil)) ;escape code for <left>
       (dotimes (_ 3) (vterm-send-key "<backspace>" nil nil nil t)) ;;delete  "^[[D"
       nil)
      (t nil))))


### PR DESCRIPTION
In truth `looking-back` does not (yet) require the second argument,
but since 5161c9ca6a6107da30d411fb2ad72e01d08e5704 it claims that
it does.

Instead of merely silencing this warning it would be better to
provide a non-nil value for LIMIT.  The reason that this function
is now advertised as requiring two arguments is that it may perform
horribly if no proper limit is specified.