### PR TITLE
Enable selection for commands in copy-mode

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -1692,7 +1692,7 @@ More information see `vterm--prompt-tracking-enabled-p' and
 Move the point to the first character after the shell prompt on this line.
 If the point is already there, move to the beginning of the line.
 Effectively toggle between the two positions."
-  (interactive)
+  (interactive "^")
   (if (vterm--at-prompt-p)
       (goto-char (vterm--get-beginning-of-line))
     (goto-char (max (or (vterm--get-prompt-point) 0)
@@ -1700,7 +1700,7 @@ Effectively toggle between the two positions."
 
 (defun vterm-end-of-line ()
   "Move point to the end of the line, bypassing line wraps."
-  (interactive)
+  (interactive "^")
   (goto-char (vterm--get-end-of-line)))
 
 (defun vterm-reset-cursor-point ()


### PR DESCRIPTION
This commit enables C-a and C-e to be used with shift modifer to select region to start of line and end of line, if `shift-select-mode` is enabled.

This is done by putting "^" into interactive, for more information see, https://www.emacswiki.org/emacs/ShiftSelectMode.

Additionally, I would recommend to bind M-w (king-ring-save) to `vterm-copy-mode-done` also, which is the default key bind to region save, this change I haven't introduce in this commit. I use this bind all the time, and had to manually quite copy-mode using C-c C-t, instead of using return.

I mentioned the above here, since this commit is about introducing better integration between vterm and emacs.