### PR TITLE
try fix #598.  treat `ESC =` as control seq.

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -1375,7 +1375,7 @@ value of `vterm-buffer-name'."
    "\\(?:[\r\n\000\007\t\b\016\017]\\|"
    ;; a C1 escape coded character (see [ECMA-48] section 5.3 "Elements
    ;; of the C1 set"),
-   "\e\\(?:[DM78c]\\|"
+   "\e\\(?:[DM78c=]\\|"
    ;; another Emacs specific control sequence for term.el,
    "AnSiT[^\n]+\n\\|"
    ;; another Emacs specific control sequence for vterm.el


### PR DESCRIPTION
see https://invisible-island.net/xterm/ctlseqs/ctlseqs.html says 
  ESC =     Application Keypad (DECKPAM).


when run ghci it echo "\e=Prelude>",
I think `\e=` should be treat as  control seq?