### PR TITLE
Fix type for vterm-clear-scrollbark-when-clearing

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -231,7 +231,7 @@ screen in vterm buffers.
 If `vterm-clear-scrollback-when-clearing' is nil, `vterm-clear'
 clears only the screen, so the scrollback is accessible moving
 the point up."
-  :type 'number
+  :type 'boolean
   :group 'vterm)
 
 (defcustom vterm-keymap-exceptions


### PR DESCRIPTION
Title says it all, it is listed a number but expects a boolean