### PR TITLE
Support clearing scrollback from terminal apps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,10 @@ if (USE_SYSTEM_LIBVTERM)
 #    add_compile_definitions(VTermStringFragmentNotExists)
     add_definitions(-DVTermSelectionMaskNotExists)
     endif()
-
+    execute_process(COMMAND  grep -c "sb_clear" "${LIBVTERM_INCLUDE_DIR}/vterm.h" OUTPUT_VARIABLE VTermSBClearExists)
+    if (${VTermSBClearExists} EQUAL "0")
+      add_definitions(-VTermSBClearNotExists)
+    endif()
   else()
     message(STATUS "System libvterm not found: libvterm will be downloaded and compiled as part of the build process")
   endif()
@@ -70,7 +73,7 @@ else()
 
   ExternalProject_add(libvterm
     GIT_REPOSITORY https://github.com/Sbozzolo/libvterm-mirror.git
-    GIT_TAG 15133bba2c0bce32baabbf91610a2450495fea02
+    GIT_TAG 64f1775952dbe001e989f2ab679563b54f2fca55
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${LIBVTERM_BUILD_COMMAND} "CFLAGS='-fPIC'"
     BUILD_IN_SOURCE ON

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -79,6 +79,7 @@ typedef struct Term {
   // window height has increased) and must be deleted from the terminal buffer
   int sb_pending;
   int sb_pending_by_height_decr;
+  bool sb_clear_pending;
   long linenum;
   long linenum_added;
 


### PR DESCRIPTION
Add support for the `sb_clear` callback, which enables terminal apps to clear the scrollback of the terminal.  Support for this callback was added in vterm 0.3, so I've updated the SHA to download that version in the auto-download case.  This is particularly important to run terminal apps like `jest` where the scrollback is often cleared for clarity