### PR TITLE
Use `prompt_pwd` to format `/home/myuser/mydir` as `~/mydir`

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ For `fish`,
 function fish_title
     hostname
     echo ":"
-    pwd
+    prompt_pwd
 end
 ```
 See [zsh and bash](http://tldp.org/HOWTO/Xterm-Title-4.html) and [fish

--- a/etc/emacs-vterm.fish
+++ b/etc/emacs-vterm.fish
@@ -30,7 +30,7 @@ end
 function fish_title
     hostname
     echo ":"
-    pwd
+    prompt_pwd
 end
 
 # With vterm_cmd you can execute Emacs commands directly from the shell.


### PR DESCRIPTION
This commit improves documentation for [vterm-buffer-name-string](https://github.com/akermu/emacs-libvterm#vterm-buffer-name-string).
Fish has a utility function [`prompt_pwd`](https://fishshell.com/docs/current/cmds/prompt_pwd.html), which prints pwd suitable for prompt.
