### PR TITLE
config vterm-environment in dir_locals

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -670,6 +670,11 @@ Exceptions are defined by `vterm-keymap-exceptions'."
        (let ((font-height (expt text-scale-mode-step text-scale-mode-amount)))
          (setq vterm--linenum-remapping
                (face-remap-add-relative 'line-number :height font-height))))
+  (hack-dir-local-variables)
+  (let ((vterm-env (assq 'vterm-environment dir-local-variables-alist)))
+    (when vterm-env
+      (make-local-variable 'vterm-environment)
+      (setq vterm-environment (cdr vterm-env))))
   (let ((process-environment (append vterm-environment
                                      `(,(concat "TERM="
                                                 vterm-term-environment-variable)


### PR DESCRIPTION
The environment of each project may be different, and "dir_locals.el" provides an excellent way to configure each project separately. This patch enables config project environment by using "vterm-environment."