### PR TITLE
Use same shell as TRAMP on remotes.

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -755,6 +755,7 @@ Exceptions are defined by `vterm-keymap-exceptions'."
   (if (ignore-errors (file-remote-p default-directory))
       (with-parsed-tramp-file-name default-directory nil
         (or (cadr (assoc method vterm-tramp-shells))
+            (with-connection-local-variables shell-file-name)
             vterm-shell))
     vterm-shell))
 


### PR DESCRIPTION
Fixes: https://github.com/akermu/emacs-libvterm/issues/567

If emacs-vterm is started on a remote, use the same shell as TRAMP. That will guarantee that the shell exists on the remote.

A shell could be chosen using `vterm-tramp-shells', but it tied to a specific TRAMP method. However, the same method (ssh) could be used to connected to different remotes, each with different default shell. So, we could use TRAMP to get the shell on per-remote basis.