### PR TITLE
Fix vterm--remove-fake-newlines when in an empty buffer

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -1789,6 +1789,7 @@ If REMEMBERING-POS-P is not nil remembering their positions in a buffer-local
 
     (goto-char (point-max))
     (when (and (bolp)
+               (not (bobp))
                (get-text-property (1- (point)) 'vterm-line-wrap))
       (forward-char -1)
       (when remembering-pos-p


### PR DESCRIPTION
When the buffer is empty,

```lisp
(get-text-property (1- (point)) 'vterm-line-wrap)
```

throws an error.

This situation happens when the empty string is passed as argument to
`vterm--filter-buffer-substring`.