### PR TITLE
Allow to find beginnig and end of line from a specific point

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -1679,9 +1679,12 @@ in README."
                    (when pt (goto-char (1- pt))))))
     (term-previous-prompt n)))
 
-(defun vterm--get-beginning-of-line ()
-  "Find the start of the line, bypassing line wraps."
+(defun vterm--get-beginning-of-line (&optional pt)
+  "Find the start of the line, bypassing line wraps.
+If PT is specified, find it's beginning of the line instead of the beginning
+of the line at cursor."
   (save-excursion
+    (when pt (goto-char pt))
     (beginning-of-line)
     (while (and (not (bobp))
                 (get-text-property (1- (point)) 'vterm-line-wrap))
@@ -1689,9 +1692,12 @@ in README."
       (beginning-of-line))
     (point)))
 
-(defun vterm--get-end-of-line ()
-  "Find the start of the line, bypassing line wraps."
+(defun vterm--get-end-of-line (&optional pt)
+  "Find the start of the line, bypassing line wraps.
+If PT is specified, find it's end of the line instead of the end
+of the line at cursor."
   (save-excursion
+    (when pt (goto-char pt))
     (end-of-line)
     (while (get-text-property (point) 'vterm-line-wrap)
       (forward-char)


### PR DESCRIPTION
I didn't find an easy way to determine whether the cursor is in the last prompt line or what the prompt line number even is. And one cannot assume the prompt line is the last line of the buffer beacuse vterm is basically a rectangle filling the whole buffer. As a consequence `(line-number-at-pos (point-max))` _doesn't work_ because `(point-max)` _doesn't work_.

With this patch, it is possible to find the prompt line using:

    (line-number-at-pos (vterm--get-beginning-of-line
                         (vterm--get-cursor-point)))))

And in case the command in prompt is long and wraps into multiple lines, its end can be found using:

    (line-number-at-pos (vterm--get-end-of-line
                         (vterm--get-cursor-point)))))