### PR TITLE
Add handling for the terminal bell

### DIFF
--- a/elisp.c
+++ b/elisp.c
@@ -33,6 +33,7 @@ emacs_value Flist;
 emacs_value Fnth;
 emacs_value Ferase_buffer;
 emacs_value Finsert;
+emacs_value Fding;
 emacs_value Fgoto_char;
 emacs_value Fforward_char;
 emacs_value Fforward_line;
@@ -118,6 +119,10 @@ void erase_buffer(emacs_env *env) { env->funcall(env, Ferase_buffer, 0, NULL); }
 
 void insert(emacs_env *env, emacs_value string) {
   env->funcall(env, Finsert, 1, (emacs_value[]){string});
+}
+
+void ding(emacs_env *env, emacs_value flag) {
+  env->funcall(env, Fding, 1, (emacs_value[]){flag});
 }
 
 void goto_char(emacs_env *env, int pos) {

--- a/elisp.h
+++ b/elisp.h
@@ -36,6 +36,7 @@ extern emacs_value Flist;
 extern emacs_value Fnth;
 extern emacs_value Ferase_buffer;
 extern emacs_value Finsert;
+extern emacs_value Fding;
 extern emacs_value Fgoto_char;
 extern emacs_value Fforward_char;
 extern emacs_value Fforward_line;
@@ -74,6 +75,7 @@ void add_text_properties(emacs_env *env, emacs_value string,
                          emacs_value property);
 void erase_buffer(emacs_env *env);
 void insert(emacs_env *env, emacs_value string);
+void ding(emacs_env *env, emacs_value flag);
 void goto_char(emacs_env *env, int pos);
 void forward_line(emacs_env *env, int n);
 void goto_line(emacs_env *env, int n);

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -85,6 +85,7 @@ typedef struct Term {
 
   int invalid_start, invalid_end; // invalid rows in libvterm screen
   bool is_invalidated;
+  bool queued_bell;
 
   Cursor cursor;
   char *title;


### PR DESCRIPTION
This PR sets the `bell` callback from the `VTermScreenCallbacks` struct to a function that indirectly calls the `ding` function in emacs. This will play an audible bell by default.

A user could disable the ding by putting this in their init file:
```
; disable dings (in vterm mode only)
(defun disable-vterm-bell ()
  (setq-local ring-bell-function (lambda () nil)))
(add-hook 'vterm-mode-hook 'disable-vterm-bell)
```

This [documentation page](https://www.gnu.org/software/emacs/manual/html_node/elisp/Beeping.html) describes the behavior and user-options for `ding`.

Information is lost in some terminal applications when there is no terminal bell, for example scrolling to the bottom of a file in `less`, or reaching the top of your bash history when using Ctrl+R to cycle through history. I had queried about the terminal bell in #580. This code sets the previously unset `bell` callback to enable that feature.