### PR TITLE
Allow different foreground/background colors for same ANSI index

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,9 @@ is a global minor mode in Emacs, you can use `M-x blink-cursor-mode` to toggle.
 
 ## Colors
 
-Customize the following faces to your liking.
+Customize the following faces to your liking. It is possible to specify
+different colors for foreground and background via the `:foreground` and
+`:background` attributes.
 
 - vterm-color-black
 - vterm-color-red

--- a/README.md
+++ b/README.md
@@ -529,9 +529,7 @@ is a global minor mode in Emacs, you can use `M-x blink-cursor-mode` to toggle.
 
 ## Colors
 
-Set the `:foreground` and `:background` attributes of the following faces to a
-color you like. The `:foreground` is ansi color 0-7, the `:background` attribute
-is ansi color 8-15.
+Customize the following faces to your liking.
 
 - vterm-color-black
 - vterm-color-red
@@ -541,6 +539,14 @@ is ansi color 8-15.
 - vterm-color-magenta
 - vterm-color-cyan
 - vterm-color-white
+- vterm-color-bright-black
+- vterm-color-bright-red
+- vterm-color-bright-green
+- vterm-color-bright-yellow
+- vterm-color-bright-blue
+- vterm-color-bright-magenta
+- vterm-color-bright-cyan
+- vterm-color-bright-white
 
 ## Directory tracking and Prompt tracking
 

--- a/elisp.c
+++ b/elisp.c
@@ -42,6 +42,7 @@ emacs_value Frecenter;
 emacs_value Fset_window_point;
 emacs_value Fwindow_body_height;
 emacs_value Fpoint;
+emacs_value Fapply;
 
 emacs_value Fput_text_property;
 emacs_value Fadd_text_properties;
@@ -182,9 +183,9 @@ void set_cursor_blink(emacs_env *env, bool blink) {
                (emacs_value[]){env->make_integer(env, blink)});
 }
 
-emacs_value vterm_get_color(emacs_env *env, int index) {
+emacs_value vterm_get_color(emacs_env *env, int index, emacs_value args) {
   emacs_value idx = env->make_integer(env, index);
-  return env->funcall(env, Fvterm_get_color, 1, (emacs_value[]){idx});
+  return env->funcall(env, Fapply, 3, (emacs_value[]){ Fvterm_get_color, idx, args });
 }
 
 void set_title(emacs_env *env, emacs_value string) {

--- a/elisp.h
+++ b/elisp.h
@@ -29,6 +29,7 @@ extern emacs_value Qrear_nonsticky;
 extern emacs_value Qvterm_prompt;
 
 // Emacs functions
+extern emacs_value Fapply;
 extern emacs_value Fblink_cursor_mode;
 extern emacs_value Fsymbol_value;
 extern emacs_value Flength;
@@ -91,7 +92,7 @@ emacs_value selected_window(emacs_env *env);
 void set_title(emacs_env *env, emacs_value string);
 void set_directory(emacs_env *env, emacs_value string);
 void vterm_invalidate(emacs_env *env);
-emacs_value vterm_get_color(emacs_env *env, int index);
+emacs_value vterm_get_color(emacs_env *env, int index, emacs_value args);
 emacs_value vterm_eval(emacs_env *env, emacs_value string);
 emacs_value vterm_set_selection(emacs_env *env, emacs_value selection_target,
                                 emacs_value selection_data);

--- a/vterm.el
+++ b/vterm.el
@@ -425,58 +425,98 @@ copy-mode and set to nil on leaving."
 
 (defface vterm-color-black
   `((t :inherit term-color-black))
-  "Face used to render black color code.
-The foreground color is used as ANSI color 0 and the background
-color is used as ANSI color 8."
+  "Face used to render black color code."
   :group 'vterm)
 
 (defface vterm-color-red
   `((t :inherit term-color-red))
-  "Face used to render red color code.
-The foreground color is used as ANSI color 1 and the background
-color is used as ANSI color 9."
+  "Face used to render red color code."
   :group 'vterm)
 
 (defface vterm-color-green
   `((t :inherit term-color-green))
-  "Face used to render green color code.
-The foreground color is used as ANSI color 2 and the background
-color is used as ANSI color 10."
+  "Face used to render green color code."
   :group 'vterm)
 
 (defface vterm-color-yellow
   `((t :inherit term-color-yellow))
-  "Face used to render yellow color code.
-The foreground color is used as ANSI color 3 and the background
-color is used as ANSI color 11."
+  "Face used to render yellow color code."
   :group 'vterm)
 
 (defface vterm-color-blue
   `((t :inherit term-color-blue))
-  "Face used to render blue color code.
-The foreground color is used as ANSI color 4 and the background
-color is used as ANSI color 12."
+  "Face used to render blue color code."
   :group 'vterm)
 
 (defface vterm-color-magenta
   `((t :inherit term-color-magenta))
-  "Face used to render magenta color code.
-The foreground color is used as ansi color 5 and the background
-color is used as ansi color 13."
+  "Face used to render magenta color code."
   :group 'vterm)
 
 (defface vterm-color-cyan
   `((t :inherit term-color-cyan))
-  "Face used to render cyan color code.
-The foreground color is used as ansi color 6 and the background
-color is used as ansi color 14."
+  "Face used to render cyan color code."
   :group 'vterm)
 
 (defface vterm-color-white
   `((t :inherit term-color-white))
-  "Face used to render white color code.
-The foreground color is used as ansi color 7 and the background
-color is used as ansi color 15."
+  "Face used to render white color code."
+  :group 'vterm)
+
+(defface vterm-color-bright-black
+  `((t :inherit ,(if (facep 'term-color-bright-black)
+                     'term-color-bright-black
+                   'term-color-black)))
+  "Face used to render bright black color code."
+  :group 'vterm)
+
+(defface vterm-color-bright-red
+  `((t :inherit ,(if (facep 'term-color-bright-red)
+                     'term-color-bright-red
+                   'term-color-red)))
+  "Face used to render bright red color code."
+  :group 'vterm)
+
+(defface vterm-color-bright-green
+  `((t :inherit ,(if (facep 'term-color-bright-green)
+                     'term-color-bright-green
+                   'term-color-green)))
+  "Face used to render bright green color code."
+  :group 'vterm)
+
+(defface vterm-color-bright-yellow
+  `((t :inherit ,(if (facep 'term-color-bright-yellow)
+                     'term-color-bright-yellow
+                   'term-color-yellow)))
+  "Face used to render bright yellow color code."
+  :group 'vterm)
+
+(defface vterm-color-bright-blue
+  `((t :inherit ,(if (facep 'term-color-bright-blue)
+                     'term-color-bright-blue
+                   'term-color-blue)))
+  "Face used to render bright blue color code."
+  :group 'vterm)
+
+(defface vterm-color-bright-magenta
+  `((t :inherit ,(if (facep 'term-color-bright-magenta)
+                     'term-color-bright-magenta
+                   'term-color-magenta)))
+  "Face used to render bright magenta color code."
+  :group 'vterm)
+
+(defface vterm-color-bright-cyan
+  `((t :inherit ,(if (facep 'term-color-bright-cyan)
+                     'term-color-bright-cyan
+                   'term-color-cyan)))
+  "Face used to render bright cyan color code."
+  :group 'vterm)
+
+(defface vterm-color-bright-white
+  `((t :inherit ,(if (facep 'term-color-bright-white)
+                     'term-color-bright-white
+                   'term-color-white)))
+  "Face used to render bright white color code."
   :group 'vterm)
 
 (defface vterm-color-underline
@@ -501,7 +541,15 @@ Only background is used."
    vterm-color-blue
    vterm-color-magenta
    vterm-color-cyan
-   vterm-color-white]
+   vterm-color-white
+   vterm-color-bright-black
+   vterm-color-bright-red
+   vterm-color-bright-green
+   vterm-color-bright-yellow
+   vterm-color-bright-blue
+   vterm-color-bright-magenta
+   vterm-color-bright-cyan
+   vterm-color-bright-white]
   "Color palette for the foreground and background.")
 
 (defvar-local vterm--term nil
@@ -1615,13 +1663,9 @@ the `vterm-color-underline' face is used in this case.
 -12 background for cells with inverse video attribute, background
 of the `vterm-color-inverse-video' face is used in this case."
   (cond
-   ((and (>= index 0) (< index 8))
+   ((and (>= index 0) (< index 16))
     (face-foreground
      (elt vterm-color-palette index)
-     nil 'default))
-   ((and (>= index 8) (< index 16))
-    (face-background
-     (elt vterm-color-palette (% index 8))
      nil 'default))
    ((= index -11)
     (face-foreground 'vterm-color-underline nil 'default))


### PR DESCRIPTION
So far, vterm has been using `:foreground` attribute of its faces for regular colors (0-7), and `:background` attribute for bright colors (8-15). This is counter-intuitive and limits customization possibilities: In particular, it has been impossible to specify different color values, depending on whether the ANSI index is used for background or foreground.

Emacs' `ansi-color-*` and `term-color-*` faces allow specifying colors in this way by setting the `:foreground` and `:background` attributes respectively, but have been missing the bright half of the palette. The palette has been completed in Emacs 28 with new faces `ansi-color-bright-*` and `term-color-bright-*`.

This PR extends the vterm color handling with new bright color faces similarly to `term.el` and `ansi-color.el` and adjusts the `vterm--get-color` logic to use `:foreground` or `:background` depending on whether the index is used as background or foreground. It also simplifies handling of two special cases (default foreground with an underline and default background with inverse video attribute) mapped as special indices -11 and -12. Instead, the relevant attributes (underline and inverse-video) are passed to `vterm--get-color`, where these cases are handled in Lisp instead of C.

I have not found a backwards-compatible way of adding these new faces, hence the 28.1 bump (Emacs 25 is 7 years old anyway). Let me know if I am missing something and there's a way to stay backwards-compatible and whether it is desired after all.