### PR TITLE
update fish shell directory tracking function

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,16 +588,8 @@ PS1=$PS1'\[$(vterm_prompt_end)\]'
 For `fish`, put this in your `~/.config/fish/config.fish`:
 
 ```fish
-function vterm_prompt_end;
+function vterm_prompt_end --on-variable PWD
     vterm_printf '51;A'(whoami)'@'(hostname)':'(pwd)
-end
-functions --copy fish_prompt vterm_old_fish_prompt
-function fish_prompt --description 'Write out the prompt; do not replace this. Instead, put this at end of your file.'
-    # Remove the trailing newline from the original prompt. This is done
-    # using the string builtin from fish, but to make sure any escape codes
-    # are correctly interpreted, use %b for printf.
-    printf "%b" (string join "\n" (vterm_old_fish_prompt))
-    vterm_prompt_end
 end
 ```
 


### PR DESCRIPTION
for current fish version `3.6.1`, the directory tracking instruction on README does not work.

set the `vterm_prompt_end` function to trigger whenever the current directory changes. This can be done using the **--on-variable PWD** hook.

This modification ensures that vterm_prompt_end is called every time the PWD variable changes, which occurs whenever user change directories.

With the above change, we don't need to call vterm_prompt_end from within fish_prompt anymore.