### PR TITLE
Ensures the starting col is the same as later calculated

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -751,7 +751,7 @@ Exceptions are defined by `vterm-keymap-exceptions'."
         (inhibit-eol-conversion nil)
         (coding-system-for-read 'binary)
         (process-adaptive-read-buffering nil)
-        (width (max (- (window-body-width) (vterm--get-margin-width))
+        (width (max (- (window-max-chars-per-line) (vterm--get-margin-width))
                     vterm-min-window-width)))
     (setq vterm--term (vterm--new (window-body-height)
                                   width vterm-max-scrollback


### PR DESCRIPTION
When using emacs in a terminal the initial column count is off by one.  This only happens on initial creation of a vterm.  After re-sizing the terminal the right column count is used. 

Replacing `windows-body-width` with `windows-max-chars-per-line` resolve this issue. This is mostly driven because the last column when in terminal mode is not really usable. This change does not seem to affect the gui version emacs in any way. 

Rendering in terminal emacs without fix: 
![image](https://github.com/akermu/emacs-libvterm/assets/1245807/8725a675-4345-4eae-805d-e7f377b921a3)

Rendering in terminal emacs with fix: 
![image](https://github.com/akermu/emacs-libvterm/assets/1245807/9bea0c96-0d96-4160-b169-70b9dae36273)

Rendering will fix its self once you resized the window, with something like M-x. You can also inspect the changes in col values before and aver resize with `echo $(tput cols)`.  
