### PR TITLE
Fix backtrace on doubleclick in vterm

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -1166,12 +1166,9 @@ Argument ARG is passed to `yank'"
 But when clicking to the unused area below the last prompt,
 move the cursor to the prompt area."
   (interactive "e\np")
-  (let ((pt (mouse-set-point event promote-to-region)))
-    (if (= (count-words pt (point-max)) 0)
-        (vterm-reset-cursor-point)
-      pt))
-  ;; Otherwise it selects text for every other click
-  (keyboard-quit))
+  (if (> (count-words (posn-point (event-end event)) (point-max)) 0)
+      (mouse-set-point event promote-to-region)
+    (vterm-reset-cursor-point)))
 
 (defun vterm-send-string (string &optional paste-p)
   "Send the string STRING to vterm.


### PR DESCRIPTION
Hi,

Backtrace happened when I double click in a vterm,
it caused by `(mouse-set-point event..)` return `nil` for "double-mouse-1" event, 
then lead the `count-words` failed with `nil`.
>Debugger entered--Lisp error: (wrong-type-argument integer-or-marker-p nil)
  count-words(nil 370)
  (= (count-words pt (point-max)) 0)
  (if (= (count-words pt (point-max)) 0) (vterm-reset-cursor-point) pt)
  (let ((pt (mouse-set-point event promote-to-region))) (if (= (count-words pt (point-max)) 0) (vterm-reset-cursor-point) pt))
  vterm-mouse-set-point((double-mouse-1 (#<window 335 on *Default-multivterm-1*> 193 (1273 . 277) 105236234 nil 193 (63 . 6) nil (13 . 19) (20 . 43)) 2) 1)
  funcall-interactively(vterm-mouse-set-point (double-mouse-1 (#<window 335 on *Default-multivterm-1*> 193 (1273 . 277) 105236234 nil 193 (63 . 6) nil (13 . 19) (20 . 43)) 2) 1)
  command-execute(vterm-mouse-set-point)

This patch will fix the backtrace.
Please help review and merge the changes.