### PR TITLE
Support overriding SB_MAX at compile-time with -D defines

### DIFF
--- a/vterm-module.h
+++ b/vterm-module.h
@@ -23,7 +23,9 @@
 
 VTERM_EXPORT int plugin_is_GPL_compatible;
 
+#ifndef SB_MAX
 #define SB_MAX 100000 // Maximum 'scrollback' value.
+#endif
 
 #ifndef MIN
 #define MIN(X, Y) ((X) < (Y) ? (X) : (Y))


### PR DESCRIPTION
This allows the user to select the scrollback buffer size via compiler preprocessor defines (instead of having to edit the source file) and falls back to the statically configured `SB_MAX` if there is no `-DSB_MAX=$VALUE` given.


