### PR TITLE
Do our best to restore tab characters

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -765,6 +765,7 @@ Exceptions are defined by `vterm-keymap-exceptions'."
     (setq-local scroll-margin 0)
     (setq-local hscroll-margin 0)
     (setq-local hscroll-step 1)
+    (setq-local tab-width 8)
     (setq-local truncate-lines t)
 
 


### PR DESCRIPTION
```
$ echo -e 'abc\t\t\tabc'
  # use mouse to select and copy the output, it should contain three tabs,
  # not expand to spaces.

$ touch 2024中华人民共和国
$ for i in `seq 1 20`; do touch text-text-text-text-text-text-$i; done 
$ gls
$ gls -C | cat
  # It should align correctly.
```