### PR TITLE
prevent empty input messing up libvterm

### DIFF
--- a/vterm-module.c
+++ b/vterm-module.c
@@ -1345,12 +1345,14 @@ emacs_value Fvterm_write_input(emacs_env *env, ptrdiff_t nargs,
                                emacs_value args[], void *data) {
   Term *term = env->get_user_ptr(env, args[0]);
   ptrdiff_t len = string_bytes(env, args[1]);
-  char bytes[len];
 
-  env->copy_string_contents(env, args[1], bytes, &len);
+  if (len > 0) {
+    char bytes[len];
+    env->copy_string_contents(env, args[1], bytes, &len);
 
-  vterm_input_write(term->vt, bytes, len);
-  vterm_screen_flush_damage(term->vts);
+    vterm_input_write(term->vt, bytes, len);
+    vterm_screen_flush_damage(term->vts);
+  }
 
   return env->make_integer(env, 0);
 }


### PR DESCRIPTION
When use [lf](https://github.com/gokcehan/lf) to list files, emacs-libvterm may read partial multi-byte character, for example:

```
  $ echo -n '招聘' | hexdump -C
  00000000  e6 8b 9b e8 81 98

  (vterm--filter process "\xE6\x8B\9B")   ; get "招"
  (vterm--filter process "\xE8")          ; partial character
  (vterm--filter process "\x81\x98")      ; now full "聘"
```

The second call to `vterm-filter` calls `(vterm--write-input vterm--term "")`, this empty input may mess up libvterm internal state:

```
  M-x vterm
  (vterm--write-input vterm--term "招")
  (vterm--write-input vterm--term "")
  (vterm--write-input vterm--term "聘")
```

Then move cursor, vterm sometimes shows only "聘", this patch filters out empty input to libvterm.