### PR TITLE
don't garble partial multi-byte character after control sequence

### DIFF
--- a/vterm-module.c
+++ b/vterm-module.c
@@ -1345,12 +1345,14 @@ emacs_value Fvterm_write_input(emacs_env *env, ptrdiff_t nargs,
                                emacs_value args[], void *data) {
   Term *term = env->get_user_ptr(env, args[0]);
   ptrdiff_t len = string_bytes(env, args[1]);
-  char bytes[len];
 
-  env->copy_string_contents(env, args[1], bytes, &len);
+  if (len > 0) {
+    char bytes[len];
+    env->copy_string_contents(env, args[1], bytes, &len);
 
-  vterm_input_write(term->vt, bytes, len);
-  vterm_screen_flush_damage(term->vts);
+    vterm_input_write(term->vt, bytes, len);
+    vterm_screen_flush_damage(term->vts);
+  }
 
   return env->make_integer(env, 0);
 }

--- a/vterm.el
+++ b/vterm.el
@@ -1522,7 +1522,7 @@ Then triggers a redraw from the module."
                                                       (- count 1 partial)))
                                   'eight-bit))
                     (cl-incf partial))
-                  (when (> count partial 0)
+                  (when (> (1+ count) partial 0)
                     (setq vterm--undecoded-bytes
                           (substring decoded-substring (- partial)))
                     (setq decoded-substring


### PR DESCRIPTION
When use [lf](https://github.com/gokcehan/lf) to list files, emacs-libvterm may read partial multi-byte character, for example:

  $ echo -n '招聘' | hexdump -C
  00000000  e6 8b 9b e8 81 98

  ; get "招", control sequence and partial character
  (vterm--filter process "\xE6\x8B\x9B\e[14;111H\xE8")

  ; now full "聘"
  (vterm--filter process "\x81\x98")

This will send "\xE8" to libvterm which is not a full character.