### PR TITLE
Fixes #731: Prevent the display of truncation characters ($)

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -813,6 +813,14 @@ Exceptions are defined by `vterm-keymap-exceptions'."
   (vterm--set-pty-name vterm--term (process-tty-name vterm--process))
   (process-put vterm--process 'adjust-window-size-function
                #'vterm--window-adjust-process-window-size)
+
+  ;; Set the truncation slot for 'buffer-display-table' to the ASCII code for a
+  ;; space character (32) to make the vterm buffer display a space instead of
+  ;; the default truncation character ($) when a line is truncated.
+  (let* ((display-table (or buffer-display-table (make-display-table))))
+    (set-display-table-slot display-table 'truncation 32)
+    (setq buffer-display-table display-table))
+
   ;; Support to compilation-shell-minor-mode
   ;; Is this necessary? See vterm--compilation-setup
   (setq next-error-function 'vterm-next-error-function)


### PR DESCRIPTION
This pull request fixes the issue #731 where the $ symbol appears at the end of some lines.

It usually happens when the user calls `text-scale-increase` or `text-scale-decrease` to change the font size.