### PR TITLE
Fix warnings in `vterm_printf()` and `clear` sh/bash shell functions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,9 @@ For `bash` or `zsh`, put this in your `.zshrc` or `.bashrc`
 
 ```sh
 vterm_printf() {
-    if [ -n "$TMUX" ] && ([ "${TERM%%-*}" = "tmux" ] || [ "${TERM%%-*}" = "screen" ]); then
+    if [ -n "$TMUX" ] \
+        && { [ "${TERM%%-*}" = "tmux" ] \
+            || [ "${TERM%%-*}" = "screen" ]; }; then
         # Tell tmux to pass the escape sequences through
         printf "\ePtmux;\e\e]%s\007\e\\" "$1"
     elif [ "${TERM%%-*}" = "screen" ]; then
@@ -331,8 +333,8 @@ fi
 For `bash`, put this in your `.bashrc`:
 
 ```bash
-if [[ "$INSIDE_EMACS" = 'vterm' ]]; then
-    function clear() {
+if [ "$INSIDE_EMACS" = 'vterm' ]; then
+    clear() {
         vterm_printf "51;Evterm-clear-scrollback";
         tput clear;
     }


### PR DESCRIPTION
This pull request updates README.md:

- Replaces `clear` with a POSIX-compliant function,
- Fixes the ShellCheck warning [SC2235](https://www.shellcheck.net/wiki/SC2235) in `vterm_printf()` ("Use { ..; } instead of (..) to avoid subshell overhead")
  > You appear to be using (..) to group test commands. This creates a subshell, making it unnecessarily slow. Avoid this by using { ..; } to group.
  > Be careful to note that unlike (..), this requires both a space after the { and a semicolon before the }.
  > For example, (cmd), (cmd;) and ( cmd ) are all valid, but {cmd}, {cmd;} and { cmd } are all syntax errors because they lack either or both of the spaces and semicolon. The correct form is { cmd; }
