### PR TITLE
Match vterm-tramp-shells type with custom type. Fixes #689

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -172,8 +172,9 @@ the executable."
   :type 'string
   :group 'vterm)
 
-(defcustom vterm-tramp-shells
-  '(("ssh" login-shell) ("scp" login-shell) ("docker" "/bin/sh"))
+(defcustom vterm-tramp-shells '(("ssh" . login-shell)
+                                ("scp" . login-shell)
+                                ("docker" . "/bin/sh"))
   "The shell that gets run in the vterm for tramp.
 
 `vterm-tramp-shells' has to be a list of pairs of the format:


### PR DESCRIPTION
The customs type is alist so make it one.
Now that the shell is correctly extracted from the value using cdr
instead of cadr the type value can be changed to match custom.