### PR TITLE
README: link the issue of running on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For the long answer, let us discuss the differences between `eshell`, `shell`,
   `vterm` outperforms `term` and has a nearly universal compatibility with
   terminal applications.
 
-Vterm is not for you if you are using Windows, or if you cannot set up Emacs
+Vterm is not for you [if you are using Windows](https://github.com/akermu/emacs-libvterm/issues/12), or if you cannot set up Emacs
 with support for modules. Otherwise, you should try vterm, as it provides a
 superior terminal experience in Emacs.
 


### PR DESCRIPTION
It seems there is demand for making this work on Windows, so would be nice if the text that says it doesn't work would be linked to the issue that contains the research. This will allow interested people *(if such appear)* to avoid researching everything from scratch, but rather basing their work on the information already done by others.

This came up on SE: https://emacs.stackexchange.com/questions/82896/error-use-package-vterm-catch-searching-for-program-no-such-file-or-direct/82909#82909