### PR TITLE
Add vterm-ignore-cursor-change

### DIFF
--- a/vterm-module.h
+++ b/vterm-module.h
@@ -118,6 +118,7 @@ typedef struct Term {
   bool disable_underline;
   bool disable_inverse_video;
   bool ignore_blink_cursor;
+  bool ignore_cursor_change;
 
   char *cmd_buffer;
 

--- a/vterm.el
+++ b/vterm.el
@@ -400,6 +400,11 @@ you can use `M-x blink-cursor-mode` to toggle."
   :type 'boolean
   :group 'vterm)
 
+(defcustom vterm-ignore-cursor-change nil
+  "When t, vterm will ignore request from application to modify cursor shape or visibility."
+  :type 'boolean
+  :group 'vterm)
+
 (defcustom vterm-copy-exclude-prompt t
   "When not-nil, the prompt is not included by `vterm-copy-mode-done'."
   :type 'boolean
@@ -778,7 +783,8 @@ Exceptions are defined by `vterm-keymap-exceptions'."
                                   vterm-disable-underline
                                   vterm-disable-inverse-video
                                   vterm-ignore-blink-cursor
-                                  vterm-set-bold-highbright))
+                                  vterm-set-bold-highbright
+                                  vterm-ignore-cursor-change))
     (setq buffer-read-only t)
     (setq-local scroll-conservatively 101)
     (setq-local scroll-margin 0)


### PR DESCRIPTION
Add an option to ignore application request to modify cursor shape or visibility.

I use [meow](https://github.com/meow-edit/meow), which uses cursor shape to differentiate between normal and insert mode, so I prefer if the application cannot change the cursor shape.