### PR TITLE
Fix typo in `vterm-set-bold-highbright` variable name

### DIFF
--- a/vterm-module.c
+++ b/vterm-module.c
@@ -1233,7 +1233,7 @@ emacs_value Fvterm_new(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
   int disable_underline = env->is_not_nil(env, args[4]);
   int disable_inverse_video = env->is_not_nil(env, args[5]);
   int ignore_blink_cursor = env->is_not_nil(env, args[6]);
-  int set_bold_hightbright = env->is_not_nil(env, args[7]);
+  int set_bold_highbright = env->is_not_nil(env, args[7]);
 
   term->vt = vterm_new(rows, cols);
   vterm_set_utf8(term->vt, 1);
@@ -1247,7 +1247,7 @@ emacs_value Fvterm_new(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
   vterm_state_set_selection_callbacks(state, &selection_callbacks, term,
                                       term->selection_buf, SELECTION_BUF_LEN);
 #endif
-  vterm_state_set_bold_highbright(state, set_bold_hightbright);
+  vterm_state_set_bold_highbright(state, set_bold_highbright);
 
   vterm_screen_reset(term->vts, 1);
   vterm_screen_set_callbacks(term->vts, &vterm_screen_callbacks, term);

--- a/vterm.el
+++ b/vterm.el
@@ -383,10 +383,13 @@ This means that vterm will render bold with the default face weight."
   :type  'boolean
   :group 'vterm)
 
-(defcustom vterm-set-bold-hightbright nil
-  "When not-nil, using hightbright colors for bolded text, see #549."
+(defcustom vterm-set-bold-highbright nil
+  "When not-nil, using highbright colors for bolded text, see #549."
   :type  'boolean
   :group 'vterm)
+
+(define-obsolete-variable-alias 'vterm-set-bold-hightbright
+  'vterm-set-bold-highbright "0.0.2")
 
 (defcustom vterm-ignore-blink-cursor t
   "When t, vterm will ignore request from application to turn on/off cursor blink.
@@ -775,7 +778,7 @@ Exceptions are defined by `vterm-keymap-exceptions'."
                                   vterm-disable-underline
                                   vterm-disable-inverse-video
                                   vterm-ignore-blink-cursor
-                                  vterm-set-bold-hightbright))
+                                  vterm-set-bold-highbright))
     (setq buffer-read-only t)
     (setq-local scroll-conservatively 101)
     (setq-local scroll-margin 0)


### PR DESCRIPTION
The word “highbright” was spelled as “hightbright” in a few places.