### PR TITLE
Set up minimal GH Action to build the code

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,48 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        emacs-version:
+          - '27.2'
+          - '28.2'
+          - '29.4'
+          - '30.1'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Emacs ${{ matrix.emacs-version }}
+      uses: purcell/setup-emacs@master
+      with:
+        version: ${{ matrix.emacs-version }}
+
+    - name: Install build dependencies via Nix
+      run: |
+        # Pin to nixos-24.05 stable release for reproducibility
+        # Note: libvterm is not included - CMake downloads and builds it
+        nix profile install \
+          github:NixOS/nixpkgs/nixos-24.05#cmake \
+          github:NixOS/nixpkgs/nixos-24.05#libtool \
+          github:NixOS/nixpkgs/nixos-24.05#glib
+
+    - name: Build vterm module
+      run: |
+        mkdir build
+        cd build
+        cmake ..
+        make
+
+    - name: Test vterm module
+      run: |
+        cd build
+        make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,8 +97,23 @@ target_include_directories(vterm INTERFACE ${LIBVTERM_INCLUDE_DIR})
 # Link with libvterm
 target_link_libraries(vterm-module PUBLIC vterm)
 
-# Custom run command for testing
+# Common Emacs command setup for testing
+set(EMACS_LOAD_PATH -L ${CMAKE_SOURCE_DIR} -L ${CMAKE_BINARY_DIR})
+
+# Custom run command for interactive testing
 add_custom_target(run
-  COMMAND emacs -Q -L ${CMAKE_SOURCE_DIR} -L ${CMAKE_BINARY_DIR} --eval "\\(require \\'vterm\\)" --eval "\\(vterm\\)"
+  COMMAND emacs -Q ${EMACS_LOAD_PATH} --eval "(require 'vterm)" --eval "(vterm)"
   DEPENDS vterm-module
+  VERBATIM
+  )
+
+# Enable CMake's built-in testing framework
+enable_testing()
+
+# Test that vterm module loads successfully
+add_test(
+  NAME vterm-load
+  COMMAND emacs --batch -Q ${EMACS_LOAD_PATH}
+    --eval "(require 'vterm)"
+    --eval "(message \"Successfully loaded vterm\")"
   )

--- a/README.md
+++ b/README.md
@@ -286,8 +286,14 @@ end
 
 # Debugging and testing
 
-If you have successfully built the module, you can test it by executing the
-following command in the `build` directory:
+If you have successfully built the module, you can test it loads by executing
+the following command in the `build` directory:
+
+```sh
+make test
+```
+
+Test the new module in a clean Emacs with this command in the `build` directory:
 
 ```sh
 make run


### PR DESCRIPTION
This adds a very small smoke test to help ensure that GitHub PRs build and that the module loads.

Emacs is installed via Nix, despite the build machine being an Ubuntu VM. This seemed like the easiest and fastest way to get different versions of Emacs running on the VM: it only takes a few seconds to pull down the pre-compiled binaries.

The build uses the version of `libvterm` that CMake pulls down.