### PR TITLE
initialize `vterm-shell` the same way as `shell-mode` does

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -167,9 +167,12 @@ the executable."
 
 ;;; Options
 
-(defcustom vterm-shell shell-file-name
-  "The shell that gets run in the vterm."
-  :type 'string
+(defcustom vterm-shell nil
+  "The shell that gets run in the vterm.
+
+This should be a string or a list of strings.
+If nil, uses the shell used by `shell-mode'."
+  :type '(choice string (repeat string))
   :group 'vterm)
 
 (defcustom vterm-tramp-shells
@@ -193,6 +196,26 @@ that is used when the login-shell detection fails, e.g.,
 If no second SHELL command is specified with \\='login-shell, vterm will
 fall back to tramp's shell."
   :type '(alist :key-type string :value-type string)
+  :group 'vterm)
+
+(defcustom vterm-start-shell "/bin/sh"
+  "The shell that starts the `vterm-shell'.
+
+This should be a string or a list of strings.
+If nil, uses the shell used by `shell-mode' (minus \"-i\")."
+  :type '(choice string (repeat string))
+  :group 'vterm)
+
+(defcustom explicit-vterm-csh-args nil
+  "Args passed to inferior shell by \\[vterm], if the shell is csh.
+Value is a list of strings, which may be nil."
+  :type '(repeat (string :tag "Argument"))
+  :group 'vterm)
+
+(defcustom explicit-vterm-bash-args nil
+  "Args passed to inferior shell by \\[vterm], if the shell is bash.
+Value is a list of strings, which may be nil."
+  :type '(repeat (string :tag "Argument"))
   :group 'vterm)
 
 (defcustom vterm-buffer-name "*vterm*"
@@ -798,7 +821,7 @@ Exceptions are defined by `vterm-keymap-exceptions'."
            :name "vterm"
            :buffer (current-buffer)
            :command
-           `("/bin/sh" "-c"
+           `(,@(vterm--start-shell-command) "-c"
              ,(format
                "stty -nl sane %s erase ^? rows %d columns %d >/dev/null && exec %s"
                ;; Some stty implementations (i.e. that of *BSD) do not
@@ -892,15 +915,45 @@ for, or t to get the default shell for all methods."
           (or shell second))
       first)))
 
+(defun vterm--shell-command-core (shell-var-sym)
+  "Get the desired shell command, as a list.  Returned command list comes from
+the value of symbol SHELL-VAR-SYM as is,
+else if it is nil, return what function `shell' does:
+from variable `explicit-shell-file-name'
+ or (if that is nil) from the `ESHELL' environment variable,
+ or (if that is nil) from `shell-file-name'
+combined with the shell's explicit vterm args (not from `shell')."
+  (or (pcase (symbol-value shell-var-sym)
+        ((pred null)
+          ;; return what `shell' returns:
+          (let* ((prog (or explicit-shell-file-name
+                           (getenv "ESHELL")
+                           shell-file-name))
+                 (name (file-name-nondirectory prog))
+                 (xargs-name (intern-soft (concat "explicit-vterm-" name "-args")))
+                 (args (and xargs-name (boundp xargs-name) (symbol-value xargs-name))))
+            (when prog
+              (cons prog args))))
+        ((and (pred list-of-strings-p) val) val)
+        ((and (pred stringp) val) (list val)))
+      (user-error "%s is malformed; it must be a string or a list of strings." shell-var-sym)))
+
+(defun vterm--shell-command ()
+  "Get the shell command list that gets run in the vterm."
+  (vterm--shell-command-core 'vterm-shell))
+
+(defun vterm--start-shell-command ()
+  "Get the local shell command list that launches the above `vterm-shell'."
+  (vterm--shell-command-core 'vterm-start-shell))
+
 (defun vterm--get-shell ()
-  "Get the shell that gets run in the vterm."
-  (if (ignore-errors (file-remote-p default-directory))
-      (with-parsed-tramp-file-name default-directory nil
-        (or (vterm--tramp-get-shell method)
-            (vterm--tramp-get-shell t)
-            (with-connection-local-variables shell-file-name)
-            vterm-shell))
-    vterm-shell))
+  "Get the shell string that gets run in the vterm."
+  (or (when (ignore-errors (file-remote-p default-directory))
+        (with-parsed-tramp-file-name default-directory nil
+          (or (vterm--tramp-get-shell method)
+              (vterm--tramp-get-shell t)
+              (with-connection-local-variables shell-file-name))))
+      (string-join (vterm--shell-command) " ")))
 
 (defun vterm--bookmark-make-record ()
   "Create a vterm bookmark.


### PR DESCRIPTION
- also have a `vterm-start-shell` to customize starting the `vterm-shell`
- optionally both can default to how `shell-mode` defaults