### PR TITLE
check for whether the vterm_old_fish_prompt exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,7 +644,9 @@ For `fish`, put this in your `~/.config/fish/config.fish`:
 function vterm_prompt_end;
     vterm_printf '51;A'(whoami)'@'(hostname)':'(pwd)
 end
-functions --copy fish_prompt vterm_old_fish_prompt
+if not functions -q vterm_old_fish_prompt
+    functions --copy fish_prompt vterm_old_fish_prompt
+end
 function fish_prompt --description 'Write out the prompt; do not replace this. Instead, put this at end of your file.'
     # Remove the trailing newline from the original prompt. This is done
     # using the string builtin from fish, but to make sure any escape codes


### PR DESCRIPTION
When using fish 4.2.1, I encountered an error: 

1. functions: Function 'vterm_old_fish_prompt' already exists. Cannot create copy of 'fish_prompt'                                                                                                                         
... ~/.config/fish/functions/emacs.fish (line 48): 
... functions --copy fish_prompt vterm_old_fish_prompt
... (Type 'help functions' for related documentation)
. So, I added a check to verify whether the function already exists."