### PR TITLE
Expose full-screen invalidation for color-only redraws

### DIFF
--- a/vterm-module.c
+++ b/vterm-module.c
@@ -1361,6 +1361,14 @@ emacs_value Fvterm_redraw(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
   return env->make_integer(env, 0);
 }
 
+emacs_value Fvterm_invalidate_all(emacs_env *env, ptrdiff_t nargs,
+                                  emacs_value args[], void *data) {
+  Term *term = env->get_user_ptr(env, args[0]);
+  invalidate_terminal(term, 0, term->height);
+  term_redraw(term, env);
+  return env->make_integer(env, 0);
+}
+
 emacs_value Fvterm_write_input(emacs_env *env, ptrdiff_t nargs,
                                emacs_value args[], void *data) {
   Term *term = env->get_user_ptr(env, args[0]);
@@ -1540,6 +1548,10 @@ int emacs_module_init(struct emacs_runtime *ert) {
   fun =
       env->make_function(env, 1, 1, Fvterm_redraw, "Redraw the screen.", NULL);
   bind_function(env, "vterm--redraw", fun);
+
+  fun = env->make_function(env, 1, 1, Fvterm_invalidate_all,
+                           "Invalidate and redraw the whole screen.", NULL);
+  bind_function(env, "vterm--invalidate-all", fun);
 
   fun = env->make_function(env, 2, 2, Fvterm_write_input,
                            "Write input to vterm.", NULL);

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -148,6 +148,8 @@ emacs_value Fvterm_update(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
                           void *data);
 emacs_value Fvterm_redraw(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
                           void *data);
+emacs_value Fvterm_invalidate_all(emacs_env *env, ptrdiff_t nargs,
+                                  emacs_value args[], void *data);
 emacs_value Fvterm_write_input(emacs_env *env, ptrdiff_t nargs,
                                emacs_value args[], void *data);
 emacs_value Fvterm_set_size(emacs_env *env, ptrdiff_t nargs, emacs_value args[],

--- a/vterm.el
+++ b/vterm.el
@@ -148,6 +148,7 @@ the executable."
 (declare-function vterm--new "vterm-module")
 (declare-function vterm--update "vterm-module")
 (declare-function vterm--redraw "vterm-module")
+(declare-function vterm--invalidate-all "vterm-module")
 (declare-function vterm--write-input "vterm-module")
 (declare-function vterm--set-size "vterm-module")
 (declare-function vterm--set-pty-name "vterm-module")


### PR DESCRIPTION
## Summary

Add a native module binding, `vterm--invalidate-all`, that marks the whole
terminal grid invalid and redraws it immediately.

## Motivation

`vterm--redraw` redraws only rows already marked invalid by libvterm.  That is
efficient for normal terminal output, but it leaves no direct way for Elisp to
refresh the whole rendered grid when only Emacs-side face/color state changes.

This affects theme changes and other display-only color changes.  In those
cases the terminal contents are unchanged, so libvterm has no damaged rows, but
the existing rendered text still uses colors resolved before the face change.
Users currently work around this by briefly changing the terminal size and
restoring it, because `term_resize` invalidates all rows.

## Change

- Add `Fvterm_invalidate_all` in the native module.
- Bind it as `vterm--invalidate-all`.
- Declare the function in `vterm.el`.

The implementation calls:

```c
invalidate_terminal(term, 0, term->height);
term_redraw(term, env);
```

This exposes the existing full-grid invalidation path without requiring callers
to fake a resize.

## Validation

- `cmake -S . -B build`
- `cmake --build build`

Both pass locally.

## Related

- #744 describes vterm colors not updating after theme changes.
- The current workaround in that issue uses a size nudge to force `term_resize`
  to invalidate the whole grid.
