### PR TITLE
Fix default-directory switching to default TRAMP method

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -1720,7 +1720,10 @@ If N is negative backward-line from end of buffer."
                   (progn
                     (when (file-directory-p dir)
                       (setq directory (file-name-as-directory dir))))
-                (setq directory (file-name-as-directory (concat "/-:" path))))))
+                (let ((method (if (tramp-tramp-file-p default-directory)
+                                  (tramp-file-name-method (tramp-dissect-file-name default-directory))
+                                tramp-default-method-marker)))
+                  (setq directory (file-name-as-directory (concat tramp-prefix-format method tramp-postfix-method-format path)))))))
         (when (file-directory-p path)
           (setq directory (file-name-as-directory path))))
       directory)))


### PR DESCRIPTION
When `vterm--get-directory` detects that the prompt is from a remote machine, it will prepend `/-:` to the path, where `-` stands for the default TRAMP method `tramp-default-method` ([source](https://www.gnu.org/software/tramp/#File-name-syntax-1)).
Because the shell prompt doesn't provide any information about the TRAMP method being used falling back to the default is reasonable, but in most cases using the TRAMP method of `default-directory` is a better way to infer the correct method.

The way this issue manifested for me was that terminals opened in an [tramp-rpc](https://github.com/ArthurHeymans/emacs-tramp-rpc) session would "downgrade" from `/rpc:` to `/ssh:`.