### PR TITLE
feat: add DEL for terminal Emacs, handle C-DEL

### DIFF
--- a/vterm.el
+++ b/vterm.el
@@ -679,6 +679,8 @@ Exceptions are defined by `vterm-keymap-exceptions'."
     (define-key map [backspace]                 #'vterm-send-backspace)
     (define-key map (kbd "DEL")                 #'vterm-send-backspace)
     (define-key map [delete]                    #'vterm-send-delete)
+    (define-key map (kbd "<deletechar>")        #'vterm-send-delete) ; OKAY!
+    (define-key map [C-delete]                  #'vterm-send-ctrl-delete)
     (define-key map [M-backspace]               #'vterm-send-meta-backspace)
     (define-key map (kbd "M-DEL")               #'vterm-send-meta-backspace)
     (define-key map [C-backspace]               #'vterm-send-meta-backspace)
@@ -1120,6 +1122,11 @@ running in the terminal (like Emacs or Nano)."
   "Send `<delete>' to the libvterm."
   (interactive)
   (vterm-send-key "<delete>"))
+
+(defun vterm-send-ctrl-delete ()
+  "Send `C-<delete>' to the libvterm."
+  (interactive)
+  (vterm-send-key "<delete>" nil nil t))
 
 (defun vterm-send-meta-backspace ()
   "Send `M-<backspace>' to the libvterm."


### PR DESCRIPTION
Just handling the following cases:
- DEL in terminals: the key is interpreted as `<deletechar>` instead of `DEL`
- C-DEL: missing handling of this combination