### PR TITLE
Add OSC 8 hyperlink support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,10 @@ if (USE_SYSTEM_LIBVTERM)
     if (${VTermScreenEnableReflowExists} EQUAL "0")
       add_definitions(-DVTermScreenEnableReflowNotExists)
     endif()
+    execute_process(COMMAND  grep -c "VTERM_ATTR_URI" "${LIBVTERM_INCLUDE_DIR}/vterm.h" OUTPUT_VARIABLE VTermAttrUriExists)
+    if (${VTermAttrUriExists} EQUAL "0")
+      add_definitions(-DVTermAttrUriNotExists)
+    endif()
   else()
     message(STATUS "System libvterm not found: libvterm will be downloaded and compiled as part of the build process")
   endif()
@@ -75,9 +79,18 @@ else()
     message(FATAL_ERROR "libtool not found. Please install libtool")
   endif()
 
+  # Resolve through symlinks (straight.el symlinks this file into its build
+  # directory but does not symlink the patch, which lives next to the real
+  # CMakeLists.txt in the repository).
+  get_filename_component(VTERM_CMAKELISTS_REALPATH ${CMAKE_CURRENT_LIST_FILE} REALPATH)
+  get_filename_component(VTERM_REAL_SOURCE_DIR ${VTERM_CMAKELISTS_REALPATH} DIRECTORY)
+
   ExternalProject_add(libvterm
     GIT_REPOSITORY https://github.com/Sbozzolo/libvterm-mirror.git
     GIT_TAG 64f1775952dbe001e989f2ab679563b54f2fca55
+    # OSC 8 hyperlink support (VTERM_ATTR_URI), not yet in upstream libvterm.
+    # `git checkout -- .` first so re-running the patch step stays idempotent.
+    PATCH_COMMAND git checkout -- . COMMAND git apply ${VTERM_REAL_SOURCE_DIR}/libvterm-osc8-uri.patch
     CONFIGURE_COMMAND ""
     BUILD_COMMAND ${LIBVTERM_BUILD_COMMAND} "CFLAGS='-fPIC'" "LDFLAGS='-static'"
     BUILD_IN_SOURCE ON

--- a/elisp.c
+++ b/elisp.c
@@ -57,6 +57,7 @@ emacs_value Feq;
 emacs_value Fvterm_get_color;
 emacs_value Fvterm_eval;
 emacs_value Fvterm_set_selection;
+emacs_value Fvterm_osc8_buttonize;
 
 /* Set the function cell of the symbol named NAME to SFUN using
    the 'fset' function.  */
@@ -207,4 +208,10 @@ emacs_value vterm_set_selection(emacs_env *env, emacs_value selection_target,
                                 emacs_value selection_data) {
   return env->funcall(env, Fvterm_set_selection, 2,
                       (emacs_value[]){selection_target, selection_data});
+}
+
+emacs_value vterm_osc8_buttonize(emacs_env *env, emacs_value string,
+                                 emacs_value uri) {
+  return env->funcall(env, Fvterm_osc8_buttonize, 2,
+                      (emacs_value[]){string, uri});
 }

--- a/elisp.h
+++ b/elisp.h
@@ -60,6 +60,7 @@ extern emacs_value Feq;
 extern emacs_value Fvterm_get_color;
 extern emacs_value Fvterm_eval;
 extern emacs_value Fvterm_set_selection;
+extern emacs_value Fvterm_osc8_buttonize;
 
 // Utils
 void bind_function(emacs_env *env, const char *name, emacs_value Sfun);
@@ -96,5 +97,7 @@ emacs_value vterm_get_color(emacs_env *env, int index, emacs_value args);
 emacs_value vterm_eval(emacs_env *env, emacs_value string);
 emacs_value vterm_set_selection(emacs_env *env, emacs_value selection_target,
                                 emacs_value selection_data);
+emacs_value vterm_osc8_buttonize(emacs_env *env, emacs_value string,
+                                 emacs_value uri);
 
 #endif /* ELISP_H */

--- a/libvterm-osc8-uri.patch
+++ b/libvterm-osc8-uri.patch
@@ -1,0 +1,172 @@
+diff --git a/include/vterm.h b/include/vterm.h
+index c6124a1..747a517 100644
+--- a/include/vterm.h
++++ b/include/vterm.h
+@@ -244,6 +244,7 @@ typedef enum {
+   VTERM_ATTR_BACKGROUND, // color:  40-49 100-107
+   VTERM_ATTR_SMALL,      // bool:   73, 74, 75
+   VTERM_ATTR_BASELINE,   // number: 73, 74, 75
++  VTERM_ATTR_URI,        // number: OSC 8 hyperlink id, 0 = no link
+ 
+   VTERM_N_ATTRS
+ } VTermAttr;
+@@ -463,6 +464,9 @@ void vterm_state_set_default_colors(VTermState *state, const VTermColor *default
+ void vterm_state_set_palette_color(VTermState *state, int index, const VTermColor *col);
+ void vterm_state_set_bold_highbright(VTermState *state, int bold_is_highbright);
+ int  vterm_state_get_penattr(const VTermState *state, VTermAttr attr, VTermValue *val);
++/* Externally set a pen attribute, as if by SGR. Used by embedders that parse
++ * escapes libvterm itself does not (e.g. OSC 8 hyperlinks -> VTERM_ATTR_URI). */
++int  vterm_state_set_penattr(VTermState *state, VTermAttr attr, VTermValueType type, VTermValue *val);
+ int  vterm_state_set_termprop(VTermState *state, VTermProp prop, VTermValue *val);
+ void vterm_state_focus_in(VTermState *state);
+ void vterm_state_focus_out(VTermState *state);
+@@ -522,6 +526,7 @@ typedef struct {
+   char     width;
+   VTermScreenCellAttrs attrs;
+   VTermColor fg, bg;
++  int uri; /* opaque id set via VTERM_ATTR_URI; 0 = no link */
+ } VTermScreenCell;
+ 
+ typedef struct {
+@@ -582,8 +587,9 @@ typedef enum {
+   VTERM_ATTR_CONCEAL_MASK    = 1 << 9,
+   VTERM_ATTR_SMALL_MASK      = 1 << 10,
+   VTERM_ATTR_BASELINE_MASK   = 1 << 11,
++  VTERM_ATTR_URI_MASK        = 1 << 12,
+ 
+-  VTERM_ALL_ATTRS_MASK = (1 << 12) - 1
++  VTERM_ALL_ATTRS_MASK = (1 << 13) - 1
+ } VTermAttrMask;
+ 
+ int vterm_screen_get_attrs_extent(const VTermScreen *screen, VTermRect *extent, VTermPos pos, VTermAttrMask attrs);
+diff --git a/src/pen.c b/src/pen.c
+index 704e9d8..53c9397 100644
+--- a/src/pen.c
++++ b/src/pen.c
+@@ -182,6 +182,8 @@ INTERNAL void vterm_state_resetpen(VTermState *state)
+ 
+   state->pen.fg = state->default_fg;  setpenattr_col(state, VTERM_ATTR_FOREGROUND, state->default_fg);
+   state->pen.bg = state->default_bg;  setpenattr_col(state, VTERM_ATTR_BACKGROUND, state->default_bg);
++
++  state->pen.uri = 0;       setpenattr_int (state, VTERM_ATTR_URI, 0);
+ }
+ 
+ INTERNAL void vterm_state_savepen(VTermState *state, int save)
+@@ -205,9 +207,31 @@ INTERNAL void vterm_state_savepen(VTermState *state, int save)
+ 
+     setpenattr_col( state, VTERM_ATTR_FOREGROUND, state->pen.fg);
+     setpenattr_col( state, VTERM_ATTR_BACKGROUND, state->pen.bg);
++
++    setpenattr_int (state, VTERM_ATTR_URI,       state->pen.uri);
+   }
+ }
+ 
++int vterm_state_set_penattr(VTermState *state, VTermAttr attr, VTermValueType type, VTermValue *val)
++{
++  if(type != vterm_get_attr_type(attr))
++    return 0;
++
++  switch(attr) {
++  case VTERM_ATTR_URI:
++    state->pen.uri = val->number;
++    break;
++  default:
++    /* Only attributes without an SGR representation may be set externally */
++    return 0;
++  }
++
++  if(state->callbacks && state->callbacks->setpenattr)
++    (*state->callbacks->setpenattr)(attr, val, state->cbdata);
++
++  return 1;
++}
++
+ int vterm_color_is_equal(const VTermColor *a, const VTermColor *b)
+ {
+   /* First make sure that the two colours are of the same type (RGB/Indexed) */
+@@ -597,6 +621,10 @@ int vterm_state_get_penattr(const VTermState *state, VTermAttr attr, VTermValue
+     val->number = state->pen.baseline;
+     return 1;
+ 
++  case VTERM_ATTR_URI:
++    val->number = state->pen.uri;
++    return 1;
++
+   case VTERM_N_ATTRS:
+     return 0;
+   }
+diff --git a/src/screen.c b/src/screen.c
+index 77c0af8..a8932c6 100644
+--- a/src/screen.c
++++ b/src/screen.c
+@@ -32,6 +32,8 @@ typedef struct
+   unsigned int protected_cell : 1;
+   unsigned int dwl            : 1; /* on a DECDWL or DECDHL line */
+   unsigned int dhl            : 2; /* on a DECDHL line (1=top 2=bottom) */
++
++  int uri; /* opaque OSC 8 hyperlink id; 0 = no link */
+ } ScreenPen;
+ 
+ /* Internal representation of a screen cell */
+@@ -441,6 +443,10 @@ static int setpenattr(VTermAttr attr, VTermValue *val, void *user)
+     screen->pen.baseline = val->number;
+     return 1;
+ 
++  case VTERM_ATTR_URI:
++    screen->pen.uri = val->number;
++    return 1;
++
+   case VTERM_N_ATTRS:
+     return 0;
+   }
+@@ -693,6 +699,8 @@ static void resize_buffer(VTermScreen *screen, int bufidx, int new_rows, int new
+         dst->pen.fg = src->fg;
+         dst->pen.bg = src->bg;
+ 
++        dst->pen.uri = src->uri;
++
+         if(src->width == 2 && pos.col < (new_cols-1))
+           (dst + 1)->chars[0] = (uint32_t) -1;
+       }
+@@ -985,6 +993,8 @@ int vterm_screen_get_cell(const VTermScreen *screen, VTermPos pos, VTermScreenCe
+   cell->fg = intcell->pen.fg;
+   cell->bg = intcell->pen.bg;
+ 
++  cell->uri = intcell->pen.uri;
++
+   if(pos.col < (screen->cols - 1) &&
+      getcell(screen, pos.row, pos.col + 1)->chars[0] == (uint32_t)-1)
+     cell->width = 2;
+@@ -1108,6 +1118,8 @@ static int attrs_differ(VTermAttrMask attrs, ScreenCell *a, ScreenCell *b)
+     return 1;
+   if((attrs & VTERM_ATTR_BASELINE_MASK)    && (a->pen.baseline != b->pen.baseline))
+     return 1;
++  if((attrs & VTERM_ATTR_URI_MASK)         && (a->pen.uri != b->pen.uri))
++    return 1;
+ 
+   return 0;
+ }
+diff --git a/src/vterm.c b/src/vterm.c
+index b2f61d2..5baa1e9 100644
+--- a/src/vterm.c
++++ b/src/vterm.c
+@@ -276,6 +276,7 @@ VTermValueType vterm_get_attr_type(VTermAttr attr)
+     case VTERM_ATTR_BACKGROUND: return VTERM_VALUETYPE_COLOR;
+     case VTERM_ATTR_SMALL:      return VTERM_VALUETYPE_BOOL;
+     case VTERM_ATTR_BASELINE:   return VTERM_VALUETYPE_INT;
++    case VTERM_ATTR_URI:        return VTERM_VALUETYPE_INT;
+ 
+     case VTERM_N_ATTRS: return 0;
+   }
+diff --git a/src/vterm_internal.h b/src/vterm_internal.h
+index 6aa9007..b270c9d 100644
+--- a/src/vterm_internal.h
++++ b/src/vterm_internal.h
+@@ -50,6 +50,7 @@ struct VTermPen
+   unsigned int font:4; /* To store 0-9 */
+   unsigned int small:1;
+   unsigned int baseline:2;
++  int uri; /* opaque OSC 8 hyperlink id; 0 = no link */
+ };
+ 
+ struct VTermState

--- a/test/vterm-osc8-test.el
+++ b/test/vterm-osc8-test.el
@@ -1,0 +1,345 @@
+;;; vterm-osc8-test.el --- Tests for OSC 8 hyperlink support -*- lexical-binding: t; -*-
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;;; Commentary:
+
+;; Tests for OSC 8 hyperlink support: linked spans get the clickable
+;; `ansi-osc-hyperlink' button treatment (browse-url-data property,
+;; browse-url activation).
+;;
+;; Run from the repository root, with the module already built (the
+;; default build vendors and patches libvterm; a system libvterm
+;; without VTERM_ATTR_URI compiles the feature out and these tests
+;; will fail rather than skip):
+;;
+;;   emacs -batch -L . -l test/vterm-osc8-test.el -f ert-run-tests-batch-and-exit
+;;
+;; The tests skip themselves when the dynamic module is not built,
+;; ansi-osc is unavailable (Emacs < 29.1), or /bin/cat is missing; the
+;; end-to-end test additionally needs /bin/sh.  Most tests feed escape
+;; sequences straight to the terminal parser, so no shell round-trip
+;; is involved.
+
+;;; Code:
+
+(require 'ert)
+
+(defvar vterm-always-compile-module)
+(setq vterm-always-compile-module nil)
+
+(defvar vterm-osc8-test--available
+  ;; Probe the module directly: requiring `vterm' without it would
+  ;; prompt (or error) instead of skipping.  ansi-osc is required
+  ;; because linked spans are observed via its button convention.
+  (and (require 'vterm-module nil t)
+       (progn (require 'vterm) t)
+       (require 'ansi-osc nil t)
+       (file-executable-p "/bin/cat"))
+  "Non-nil when the module, ansi-osc, and a quiet shell are available.")
+
+(defmacro vterm-osc8-test--with-vterm (&rest body)
+  "Run BODY in a fresh vterm buffer whose shell is a quiet /bin/cat."
+  (declare (indent 0))
+  `(let* ((vterm-shell "/bin/cat")
+          (buf (generate-new-buffer " *vterm-osc8-test*")))
+     (unwind-protect
+         (with-current-buffer buf
+           (vterm-mode)
+           ,@body)
+       (let ((kill-buffer-query-functions nil))
+         (when (buffer-live-p buf)
+           (kill-buffer buf))))))
+
+(defun vterm-osc8-test--feed (str)
+  "Feed STR to the terminal parser and redraw."
+  (let ((inhibit-read-only t))
+    (vterm--write-input vterm--term str)
+    (vterm--update vterm--term)
+    (vterm--redraw vterm--term)))
+
+(defun vterm-osc8-test--links ()
+  "Return a list of (START END HREF TEXT) for all linked spans.
+HREF is the span's `browse-url-data' property."
+  (save-excursion
+    (let (res (pos (point-min)))
+      (while (< pos (point-max))
+        (let* ((href (get-text-property pos 'browse-url-data))
+               (end (or (next-single-property-change pos 'browse-url-data)
+                        (point-max))))
+          (when href
+            (push (list pos end href
+                        (buffer-substring-no-properties pos end))
+                  res))
+          (setq pos end)))
+      (nreverse res))))
+
+(defun vterm-osc8-test--find (href &optional text)
+  "Find the link span carrying HREF (and, if given, label TEXT)."
+  (seq-find (lambda (l)
+              (and (equal (nth 2 l) href)
+                   (or (null text) (equal (nth 3 l) text))))
+            (vterm-osc8-test--links)))
+
+;;; Link spans
+
+(ert-deftest vterm-osc8-labeled-bel ()
+  "A BEL-terminated OSC 8 pair labels exactly the enclosed span."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "pre \e]8;;https://example.com/a\aClick here\e]8;;\a post\r\n")
+    (let ((l (vterm-osc8-test--find "https://example.com/a")))
+      (should l)
+      (should (equal (nth 3 l) "Click here")))))
+
+(ert-deftest vterm-osc8-labeled-st ()
+  "ST-terminated OSC 8 sequences work like BEL-terminated ones."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://example.com/st\e\\ST-link\e]8;;\e\\\r\n")
+    (should (vterm-osc8-test--find "https://example.com/st" "ST-link"))))
+
+(ert-deftest vterm-osc8-id-param ()
+  "The id= parameter is accepted (and ignored: URIs are interned)."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;id=4021563000;https://example.com/pull/1\aexample#1\e]8;;\a\r\n")
+    (should (vterm-osc8-test--find "https://example.com/pull/1"
+                                   "example#1"))))
+
+(ert-deftest vterm-osc8-adjacent-links-split ()
+  "Two back-to-back links split into two spans at the exact boundary."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://a.example/\aAAA\e]8;;https://b.example/\aBBB\e]8;;\a\r\n")
+    (let ((la (vterm-osc8-test--find "https://a.example/" "AAA"))
+          (lb (vterm-osc8-test--find "https://b.example/" "BBB")))
+      (should la)
+      (should lb)
+      (should (= (nth 1 la) (nth 0 lb))))))
+
+(ert-deftest vterm-osc8-fragmented-uri ()
+  "A URI split across separate input writes is reassembled."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed "\e]8;;https://frag.example/loooo")
+    (vterm-osc8-test--feed "oooong\aFRAG\e]8;;\a\r\n")
+    (should (vterm-osc8-test--find "https://frag.example/loooooooong"
+                                   "FRAG"))))
+
+(ert-deftest vterm-osc8-wrapped-link ()
+  "A link whose label autowraps keeps the property on every row."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (let ((long-label (make-string 150 ?x)))
+      (vterm-osc8-test--feed
+       (concat "\e]8;;https://wrap.example/\a" long-label "\e]8;;\a\r\n"))
+      (let* ((spans (seq-filter
+                     (lambda (l) (equal (nth 2 l) "https://wrap.example/"))
+                     (vterm-osc8-test--links)))
+             (total (apply #'+ (mapcar
+                                (lambda (l)
+                                  (length (replace-regexp-in-string
+                                           "\n" "" (nth 3 l))))
+                                spans))))
+        (should (= total 150))))))
+
+(ert-deftest vterm-osc8-link-off ()
+  "Text after an empty-URI terminator carries no link properties."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://off.example/\aON\e]8;;\aOFFTEXT\r\n")
+    (should (vterm-osc8-test--find "https://off.example/" "ON"))
+    (goto-char (point-min))
+    (should (search-forward "OFFTEXT" nil t))
+    (should-not (get-text-property (match-beginning 0) 'browse-url-data))))
+
+(ert-deftest vterm-osc8-dedup-reuse ()
+  "Reusing a URI (interning) still labels later spans correctly."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://example.com/a\aOnce\e]8;;\a\r\n")
+    (vterm-osc8-test--feed
+     "\e]8;id=999;https://example.com/a\aAgain\e]8;;\a\r\n")
+    (should (vterm-osc8-test--find "https://example.com/a" "Once"))
+    (should (vterm-osc8-test--find "https://example.com/a" "Again"))))
+
+(ert-deftest vterm-osc8-overlong-uri-dropped ()
+  "URIs longer than the cap are treated as no-link, not truncated."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     (concat "\e]8;;https://long.example/" (make-string 2100 ?z)
+             "\aTOOLONG\e]8;;\a\r\n"))
+    (goto-char (point-min))
+    (should (search-forward "TOOLONG" nil t))
+    (should-not (get-text-property (match-beginning 0) 'browse-url-data))))
+
+(ert-deftest vterm-osc8-colored-link ()
+  "Face and link properties coexist on the same span."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e[31m\e]8;;https://red.example/\aREDLINK\e]8;;\a\e[0m\r\n")
+    (let ((l (vterm-osc8-test--find "https://red.example/" "REDLINK")))
+      (should l)
+      (should (get-text-property (nth 0 l) 'font-lock-face)))))
+
+(ert-deftest vterm-osc8-scrollback-persists ()
+  "Link properties survive when the span scrolls off-screen."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://example.com/a\aClick here\e]8;;\a\r\n")
+    (dotimes (i 60)
+      (vterm-osc8-test--feed (format "filler-%d\r\n" i)))
+    (should (vterm-osc8-test--find "https://example.com/a" "Click here"))))
+
+;;; Neighbouring OSC handlers must keep working
+
+(ert-deftest vterm-osc8-osc52-clipboard-still-works ()
+  "OSC 52 clipboard writes still reach the kill ring."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (let ((kill-ring nil)
+          (kill-ring-yank-pointer nil)
+          (vterm-enable-manipulate-selection-data-by-osc52 t))
+      (vterm-osc8-test--feed
+       (concat "\e]52;c;" (base64-encode-string "osc52-payload") "\a"))
+      (should (equal (current-kill 0) "osc52-payload")))))
+
+(ert-deftest vterm-osc8-osc51-pwd-still-works ()
+  "OSC 51 directory tracking still records the pwd."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    ;; Emit some output first so point tracks the cursor row (in a
+    ;; virgin buffer point rests at the bottom of the empty screen).
+    (vterm-osc8-test--feed "hello\r\n\e]51;A/tmp/osc51dir\a")
+    (should (equal (vterm--get-pwd-raw vterm--term
+                                       (line-number-at-pos (point)))
+                   "/tmp/osc51dir"))))
+
+;;; Button behavior
+
+(ert-deftest vterm-osc8-button-properties ()
+  "A linked span is an `ansi-osc-hyperlink' button."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://example.com/a\aClick here\e]8;;\a\r\n")
+    (let* ((l (vterm-osc8-test--find "https://example.com/a" "Click here"))
+           (pos (nth 0 l)))
+      (should l)
+      (should (equal (get-text-property pos 'browse-url-data)
+                     "https://example.com/a"))
+      (should (button-at pos))
+      (should (eq (button-type (button-at pos)) 'ansi-osc-hyperlink))
+      (should (eq (get-char-property pos 'mouse-face) 'highlight)))))
+
+(ert-deftest vterm-osc8-activation-calls-browse-url ()
+  "Activating a link invokes `browse-url' with the exact URI."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://b.example/\aBBB\e]8;;\a\r\n")
+    (let* ((l (vterm-osc8-test--find "https://b.example/" "BBB"))
+           (opened nil)
+           (browse-url-browser-function
+            (lambda (url &rest _) (setq opened url))))
+      (should l)
+      ;; browse-url-button-open resolves point through the selected
+      ;; window (mouse-set-point), so display the buffer there.
+      (save-window-excursion
+        (set-window-buffer (selected-window) (current-buffer))
+        (set-window-point (selected-window) (nth 0 l))
+        (goto-char (nth 0 l))
+        (browse-url-button-open))
+      (should (equal opened "https://b.example/")))))
+
+(ert-deftest vterm-osc8-link-keymap ()
+  "Mouse and C-c RET activate the link; plain RET stays unbound.
+RET must keep going to the terminal process."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://example.com/a\aClick here\e]8;;\a\r\n")
+    (let* ((l (vterm-osc8-test--find "https://example.com/a" "Click here"))
+           (map (and l (get-char-property (nth 0 l) 'keymap))))
+      (should (keymapp map))
+      (should (eq (lookup-key map (kbd "C-c RET")) 'browse-url-button-open))
+      (should (eq (lookup-key map (kbd "<mouse-2>")) 'browse-url-button-open))
+      (should (eq (lookup-key map (kbd "<follow-link>")) 'mouse-face))
+      (should-not (lookup-key map (kbd "RET"))))))
+
+(ert-deftest vterm-osc8-help-echo ()
+  "The hover tooltip names the target URI."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://example.com/a\aClick here\e]8;;\a\r\n")
+    (let* ((l (vterm-osc8-test--find "https://example.com/a" "Click here"))
+           (he (and l (get-char-property (nth 0 l) 'help-echo)))
+           (msg (and (functionp he)
+                     (funcall he nil (current-buffer) (nth 0 l)))))
+      (should (stringp msg))
+      (should (string-match-p (regexp-quote "https://example.com/a") msg)))))
+
+(ert-deftest vterm-osc8-no-stray-buttons ()
+  "Unlinked text carries none of the link properties."
+  (skip-unless vterm-osc8-test--available)
+  (vterm-osc8-test--with-vterm
+    (vterm-osc8-test--feed
+     "\e]8;;https://off.example/\aON\e]8;;\aOFFTEXT\r\n")
+    (goto-char (point-min))
+    (should (search-forward "OFFTEXT" nil t))
+    (let ((pos (match-beginning 0)))
+      (should-not (get-text-property pos 'browse-url-data))
+      (should-not (button-at pos)))))
+
+;;; End-to-end through a real shell on the pty
+
+(ert-deftest vterm-osc8-pty-end-to-end ()
+  "OSC 8 emitted by a real process on the pty produces a working link."
+  (skip-unless vterm-osc8-test--available)
+  (skip-unless (file-executable-p "/bin/sh"))
+  (let* ((vterm-shell "/bin/sh")
+         (buf (generate-new-buffer " *vterm-osc8-e2e*")))
+    (unwind-protect
+        (with-current-buffer buf
+          (let ((inhibit-read-only t))
+            (vterm-mode)
+            (vterm-send-string
+             (concat "printf 'pre \\033]8;;https://example.com/e2e\\007"
+                     "CLICKME\\033]8;;\\007 post\\n'"))
+            (vterm-send-return)
+            (let ((deadline (+ (float-time) 10)))
+              (while (and (< (float-time) deadline)
+                          (not (save-excursion
+                                 (goto-char (point-min))
+                                 (search-forward "CLICKME" nil t))))
+                (accept-process-output vterm--process 0.1)
+                (sit-for 0.05))))
+          (goto-char (point-min))
+          (should (search-forward "CLICKME" nil t))
+          (let ((pos (match-beginning 0)))
+            (should (equal (get-text-property pos 'browse-url-data)
+                           "https://example.com/e2e"))
+            (should (eq (button-type (button-at pos))
+                        'ansi-osc-hyperlink))))
+      (let ((kill-buffer-query-functions nil))
+        (when (buffer-live-p buf)
+          (kill-buffer buf))))))
+
+(provide 'vterm-osc8-test)
+;;; vterm-osc8-test.el ends here

--- a/vterm-module.c
+++ b/vterm-module.c
@@ -146,6 +146,11 @@ static int term_sb_pop(int cols, VTermScreenCell *cells, void *data) {
   for (col = cols_to_copy; col < (size_t)cols; col++) {
     cells[col].chars[0] = 0;
     cells[col].width = 1;
+#ifndef VTermAttrUriNotExists
+    /* cells may hold stale data from an earlier row; a stale link id would
+       otherwise resurface on blank padding cells */
+    cells[col].uri = 0;
+#endif
   }
 
   if (popped_by_height_incr) {
@@ -694,6 +699,10 @@ static bool compare_cells(VTermScreenCell *a, VTermScreenCell *b) {
   equal = equal && (a->attrs.italic == b->attrs.italic);
   equal = equal && (a->attrs.reverse == b->attrs.reverse);
   equal = equal && (a->attrs.strike == b->attrs.strike);
+#ifndef VTermAttrUriNotExists
+  /* runs must split at hyperlink boundaries so each gets its own link */
+  equal = equal && (a->uri == b->uri);
+#endif
   return equal;
 }
 
@@ -829,6 +838,17 @@ static emacs_value render_text(emacs_env *env, Term *term, char *buffer,
 
   if (props_len)
     put_text_property(env, text, Qface, properties);
+
+#ifndef VTermAttrUriNotExists
+  if (cell->uri > 0 && (size_t)cell->uri <= term->uri_table.len) {
+    const char *uri = term->uri_table.uris[cell->uri - 1];
+    emacs_value uri_string = env->make_string(env, uri, strlen(uri));
+    /* Apply clickable-link properties; the property set lives in lisp so
+       users can advise/customize it.  The helper returns the string to use
+       (make-text-button copies string args). */
+    text = vterm_osc8_buttonize(env, text, uri_string);
+  }
+#endif
 
   return text;
 }
@@ -1064,6 +1084,15 @@ void term_finalize(void *object) {
     free(term->selection_data);
     term->selection_data = NULL;
   }
+#ifndef VTermAttrUriNotExists
+  for (size_t i = 0; i < term->uri_table.len; i++) {
+    free(term->uri_table.uris[i]);
+  }
+  free(term->uri_table.uris);
+  term->uri_table.uris = NULL;
+  term->uri_table.len = 0;
+  term->uri_table.cap = 0;
+#endif
 
   for (int i = 0; i < term->lines_len; i++) {
     if (term->lines[i] != NULL) {
@@ -1127,6 +1156,58 @@ static int handle_osc_cmd_51(Term *term, char subCmd, char *buffer) {
   return 0;
 }
 
+#ifndef VTermAttrUriNotExists
+/* Hyperlink URIs longer than this are treated as "no link" rather than
+   truncated — a truncated URI would silently point somewhere else. */
+#define OSC8_MAX_URI_LEN 2048
+
+static int uri_table_intern(Term *term, const char *uri) {
+  UriTable *tbl = &term->uri_table;
+  for (size_t i = 0; i < tbl->len; i++) {
+    if (strcmp(tbl->uris[i], uri) == 0) {
+      return (int)(i + 1);
+    }
+  }
+  if (tbl->len == tbl->cap) {
+    size_t cap = tbl->cap ? tbl->cap * 2 : 16;
+    char **uris = realloc(tbl->uris, cap * sizeof(char *));
+    if (uris == NULL) {
+      return 0;
+    }
+    tbl->uris = uris;
+    tbl->cap = cap;
+  }
+  char *copy = malloc(strlen(uri) + 1);
+  if (copy == NULL) {
+    return 0;
+  }
+  strcpy(copy, uri);
+  tbl->uris[tbl->len] = copy;
+  tbl->len++;
+  return (int)tbl->len;
+}
+
+static int handle_osc_cmd_8(Term *term, char *buffer) {
+  /* OSC 8 ; params ; URI  (hyperlink, BEL- or ST-terminated).
+     buffer holds "params;URI". params (e.g. "id=...") are ignored: interning
+     dedups identical URIs, which is what the id exists for. An empty URI
+     turns the link off. */
+  char *sep = strchr(buffer, ';');
+  if (sep == NULL) {
+    return 0;
+  }
+  const char *uri = sep + 1;
+  int id = 0;
+  if (uri[0] != '\0' && strlen(uri) <= OSC8_MAX_URI_LEN) {
+    id = uri_table_intern(term, uri);
+  }
+  VTermState *state = vterm_obtain_state(term->vt);
+  VTermValue val = {.number = id};
+  vterm_state_set_penattr(state, VTERM_ATTR_URI, VTERM_VALUETYPE_INT, &val);
+  return 1;
+}
+#endif /* VTermAttrUriNotExists */
+
 static int handle_osc_cmd(Term *term, int cmd, char *buffer) {
   if (cmd == 51) {
     char subCmd = '0';
@@ -1137,6 +1218,11 @@ static int handle_osc_cmd(Term *term, int cmd, char *buffer) {
     /* ++ skip the subcmd char */
     return handle_osc_cmd_51(term, subCmd, ++buffer);
   }
+#ifndef VTermAttrUriNotExists
+  if (cmd == 8) {
+    return handle_osc_cmd_8(term, buffer);
+  }
+#endif
   return 0;
 }
 /* maybe we should drop support of libvterm < v0.2 */
@@ -1314,6 +1400,12 @@ emacs_value Fvterm_new(emacs_env *env, ptrdiff_t nargs, emacs_value args[],
   term->selection_mask = 0;
 
   term->cmd_buffer = NULL;
+
+#ifndef VTermAttrUriNotExists
+  term->uri_table.uris = NULL;
+  term->uri_table.len = 0;
+  term->uri_table.cap = 0;
+#endif
 
   term->lines = malloc(sizeof(LineInfo *) * rows);
   term->lines_len = rows;
@@ -1526,6 +1618,8 @@ int emacs_module_init(struct emacs_runtime *ert) {
   Fvterm_eval = env->make_global_ref(env, env->intern(env, "vterm--eval"));
   Fvterm_set_selection =
       env->make_global_ref(env, env->intern(env, "vterm--set-selection"));
+  Fvterm_osc8_buttonize =
+      env->make_global_ref(env, env->intern(env, "vterm--osc8-buttonize"));
 
   // Exported functions
   emacs_value fun;

--- a/vterm-module.h
+++ b/vterm-module.h
@@ -41,6 +41,17 @@ typedef struct LineInfo {
                    * prompt */
 } LineInfo;
 
+#ifndef VTermAttrUriNotExists
+/* Interned OSC 8 URIs. Ids handed to libvterm are 1-based indexes into uris;
+ * 0 means "no link". Append-only: ids embedded in scrollback cells must stay
+ * valid for the whole lifetime of the Term. */
+typedef struct UriTable {
+  char **uris;
+  size_t len;
+  size_t cap;
+} UriTable;
+#endif
+
 typedef struct ScrollbackLine {
   size_t cols;
   LineInfo *info;
@@ -119,6 +130,10 @@ typedef struct Term {
   bool ignore_blink_cursor;
 
   char *cmd_buffer;
+
+#ifndef VTermAttrUriNotExists
+  UriTable uri_table;
+#endif
 
   int pty_fd;
 } Term;

--- a/vterm.el
+++ b/vterm.el
@@ -1699,6 +1699,23 @@ If N is negative backward-line from end of buffer."
   (when vterm-buffer-name-string
     (rename-buffer (format vterm-buffer-name-string title) t)))
 
+(defun vterm--osc8-buttonize (text uri)
+  "Make TEXT, a span labeled by an OSC 8 hyperlink, a clickable link to URI.
+Called from the display module for each rendered chunk that carries a
+hyperlink.  Reuses the `ansi-osc-hyperlink' button type so links inside
+vterm look and behave like OSC 8 links in comint and compilation
+buffers: mouse-2 (or mouse-1 via `mouse-1-click-follows-link') and
+\\`C-c RET' open URI with `browse-url'.  Plain \\`RET' is deliberately
+not bound -- it must keep going to the terminal process.  On Emacs
+versions without ansi-osc (< 29.1) TEXT is returned unchanged.
+Returns the string to render: `make-text-button' buttonizes a COPY of a
+string argument, so the caller must use the return value, not TEXT."
+  (if (require 'ansi-osc nil t)
+      (make-text-button text nil
+                        'type 'ansi-osc-hyperlink
+                        'browse-url-data uri)
+    text))
+
 (defun vterm--set-directory (path)
   "Set `default-directory' to PATH."
   (let ((dir (vterm--get-directory path)))


### PR DESCRIPTION
TTY programs can use OSC 8 to emit explicit link URLs into their output, which vterm didn't support. This PR adds that, and makes the links clickable. Disclosure: this was all written by Claude Fable, up to you how you feel about that, but I've read it and think it did a pretty okay job?

https://github.com/user-attachments/assets/b4e2188d-921e-43e2-ad0c-16e9e834d116

Since libvterm is dead upstream, this adds a patch (inspired by the similar patch the neovim folks made to their vendored copy) to add the underlying OSC 8 support.

New `vterm--osc8-buttonize` helper in vterm.el implements the actual link styling/behavior. By default it reuses the same button style as comint-mode uses for OSC 8 in emacs 29.1+. (On older emacs it's currently a no-op.)