### PR TITLE
fix: avoid parsing user input as options in emacs-vterm.fish

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,7 +711,7 @@ vterm_cmd() {
 function vterm_cmd --description 'Run an Emacs command among the ones been defined in vterm-eval-cmds.'
     set -l vterm_elisp ()
     for arg in $argv
-        set -a vterm_elisp (printf '"%s" ' (string replace -a -r '([\\\\"])' '\\\\\\\\$1' $arg))
+        set -a vterm_elisp (printf '"%s" ' (string replace -a -r -- '([\\\\"])' '\\\\\\\\$1' $arg))
     end
     vterm_printf '51;E'(string join '' $vterm_elisp)
 end

--- a/etc/emacs-vterm.fish
+++ b/etc/emacs-vterm.fish
@@ -40,7 +40,7 @@ end
 function vterm_cmd --description 'Run an Emacs command among the ones defined in vterm-eval-cmds.'
     set -l vterm_elisp ()
     for arg in $argv
-        set -a vterm_elisp (printf '"%s" ' (string replace -a -r '([\\\\"])' '\\\\\\\\$1' $arg))
+        set -a vterm_elisp (printf '"%s" ' (string replace -a -r -- '([\\\\"])' '\\\\\\\\$1' $arg))
     end
     vterm_printf '51;E'(string join '' $vterm_elisp)
 end


### PR DESCRIPTION
The current implementation of `vterm_cmd` in emacs-vterm.fish will fail if passed a command line flag as input:
``` fish
$ vterm_cmd man '-l foo'

string replace: -l foo: unknown option

/nix/store/liwyg42ywbb8a1dzq19aimxvy8vbhxm5-emacs-vterm-20260406.134/share/emacs/site-lisp/elpa/vterm-20260406.134/etc/emacs-vterm.fish (line 1): 
in command substitution
        called on line 1 of file /nix/store/liwyg42ywbb8a1dzq19aimxvy8vbhxm5-emacs-vterm-20260406.134/share/emacs/site-lisp/elpa/vterm-20260406.134/etc/emacs-vterm.fish
in command substitution
        called on line 43 of file /nix/store/liwyg42ywbb8a1dzq19aimxvy8vbhxm5-emacs-vterm-20260406.134/share/emacs/site-lisp/elpa/vterm-20260406.134/etc/emacs-vterm.fish
in function 'vterm_cmd' with arguments 'man -l\ foo'

(Type 'help string' for related documentation)
```

This is the only place I have encountered this behavior; in my rudimentary testing I did not hit this bug in the bash or zsh implementations of `vterm_cmd`, but it's entirely possible that this misparsing is present in other functions.
Ideally we could take this opportunity to double-check the vterm shell scripts for similar bugs.